### PR TITLE
Fixing an issue where the input parameters were being referenced as a hash after having been converted to an array of name, value pairs.

### DIFF
--- a/lib/google/api_client/reference.rb
+++ b/lib/google/api_client/reference.rb
@@ -63,7 +63,7 @@ module Google
         self.headers = options[:headers] || {}
         if options[:media]
           self.media = options[:media]
-          upload_type = self.parameters.find{|a| ['uploadType', 'upload_type'].include?(a[0])}[1]
+          upload_type = self.parameters.find { |(k, _)| ['uploadType', 'upload_type'].include?(k) }.last
           case upload_type
           when "media"
             if options[:body] || options[:body_object]


### PR DESCRIPTION
... fact they are previously converted to an array
