### PR TITLE
Compatible multi_json >= 1.0.0

### DIFF
--- a/lib/compat/multi_json.rb
+++ b/lib/compat/multi_json.rb
@@ -1,7 +1,7 @@
 gem 'multi_json', '>= 1.0.0'
 require 'multi_json'
 
-unless MultiJson.respond_to?(:load)
+unless MultiJson.respond_to?(:adaptor)
   module MultiJson
     class <<self
       alias :load :decode


### PR DESCRIPTION
This is same problem:
https://github.com/collectiveidea/json_spec/issues/27

MultiJson always `MultiJson.respond_to?(:load)` return true, I understand, so using `MultiJson.respond_to?(:adaptor)`

Below is behavior:
https://gist.github.com/3861716#file_before_e28035d7adcbd83eca4f5b566785ccf7bd2915db.txt
https://gist.github.com/3861716#file_after_0b3a7753f9ddc414dc606f04e83c33fdae221365.txt

I have no test, but it works fine.

Fix the problem actually.
https://github.com/google/google-api-ruby-client/pull/9
https://github.com/google/google-api-ruby-client/issues/10
