### PR TITLE
Compatible multi_json >= 1.0.0 with Rails3.2.8

### DIFF
--- a/lib/compat/multi_json.rb
+++ b/lib/compat/multi_json.rb
@@ -2,7 +2,7 @@ gem 'multi_json', '>= 1.0.0'
 require 'multi_json'
 
 if !MultiJson.respond_to?(:load) || [
-  defined?(Kernel) && Kernel,
+  Kernel,
   defined?(ActiveSupport::Dependencies::Loadable) && ActiveSupport::Dependencies::Loadable
 ].compact.include?(MultiJson.method(:load).owner)
   module MultiJson


### PR DESCRIPTION
Compatible `multi_json` >= 1.0.0 with Rails3.2.8

In specific, using active_support(also rails), `MultiJson.method(:load).owner` is `ActiveSupport::Dependencies::Loadable`

In this module, owner is `ActiveSupport::Dependencies::Loadable`, but some_module if you include, this has #load method, then This does not work, I think. It's fragile.
