### PR TITLE
Consider dropping sudo from "sudo gem install" in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Be sure `http://rubygems.org/` is in your gem sources.
 
 For normal client usage, this is sufficient:
 
-    $ sudo gem install google-api-client
+    $ gem install google-api-client
 
 ## Example Usage
 


### PR DESCRIPTION
`sudo gem install` is harmful in a lot of setups.
- You end up writing `root`-owned files to userland dirs for any sort of managed Ruby environment (chruby, rvm, rbenv, etc).
- Related to above, it's a real pain to blow away the gem, or a ruby vm when you've got mixed ownership over the gems directory.
- Gems can run arbitrary code on the user's machine during install; not great practice to promote that as the default behavior.
- Depending on the user's setup, `sudo` may be dropping env vars such as `GEM_HOME`, placing gems into undesired locations.

etc.
