### PR TITLE
Update instructions in README to direct people to Github for issue reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ See the full list of [samples on Google Code](http://code.google.com/p/google-ap
 
 ## Support
 
-Please [report bugs at the project on Google Code](http://code.google.com/p/google-api-ruby-client/issues/entry). Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-api-ruby-client) about the client or APIs on [StackOverflow](http://stackoverflow.com).
+Please [report bugs at the project on Github](https://github.com/google/google-api-ruby-client/issues). Don't hesitate to [ask questions](http://stackoverflow.com/questions/tagged/google-api-ruby-client) about the client or APIs on [StackOverflow](http://stackoverflow.com).


### PR DESCRIPTION
- makes this consistent with directions on https://code.google.com/p/google-api-ruby-client/ which send people to Github
