### PR TITLE
fix "already initialized constant" warnings

### DIFF
--- a/bin/google-api
+++ b/bin/google-api
@@ -11,7 +11,6 @@ OAUTH_SERVER_PORT = 12736
 require 'rubygems'
 require 'optparse'
 require 'faraday'
-require 'faraday/utils'
 require 'webrick'
 require 'google/api_client/version'
 require 'google/api_client'

--- a/lib/google/api_client.rb
+++ b/lib/google/api_client.rb
@@ -14,7 +14,6 @@
 
 
 require 'faraday'
-require 'faraday/utils'
 require 'multi_json'
 require 'compat/multi_json'
 require 'stringio'

--- a/lib/google/api_client/request.rb
+++ b/lib/google/api_client/request.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require 'faraday'
-require 'faraday/utils'
 require 'faraday/request/multipart'
 require 'multi_json'
 require 'compat/multi_json'

--- a/spec/google/api_client/discovery_spec.rb
+++ b/spec/google/api_client/discovery_spec.rb
@@ -18,7 +18,6 @@
 require 'spec_helper'
 
 require 'faraday'
-require 'faraday/utils'
 require 'multi_json'
 require 'compat/multi_json'
 require 'signet/oauth_1/client'

--- a/spec/google/api_client_spec.rb
+++ b/spec/google/api_client_spec.rb
@@ -15,7 +15,6 @@
 require 'spec_helper'
 
 require 'faraday'
-require 'faraday/utils'
 require 'signet/oauth_1/client'
 require 'google/api_client'
 require 'google/api_client/version'


### PR DESCRIPTION
This pull request fixes "already initialized constant" warnings when using the google-api-client and faraday gems together. See: google/signet#6.

```
[project_path]/.bundle/gems/faraday-0.8.8/lib/faraday/utils.rb:16: warning: already initialized constant KeyMap
[project_path]/.bundle/gems/faraday-0.8.8/lib/faraday/utils.rb:173: warning: already initialized constant ESCAPE_RE
[project_path]/.bundle/gems/faraday-0.8.8/lib/faraday/utils.rb:183: warning: already initialized constant DEFAULT_SEP
```

Tests are passing. 

Also - if there's any way to get these into the 0.6.x gem, everyone on my team would be very grateful :)
