### PR TITLE
Small fixes to client secrets

### DIFF
--- a/lib/google/api_client.rb
+++ b/lib/google/api_client.rb
@@ -31,6 +31,7 @@ require 'google/api_client/media'
 require 'google/api_client/service_account'
 require 'google/api_client/batch'
 require 'google/api_client/gzip'
+require 'google/api_client/client_secrets'
 require 'google/api_client/railtie' if defined?(Rails::Railtie)
 
 module Google

--- a/lib/google/api_client/client_secrets.rb
+++ b/lib/google/api_client/client_secrets.rb
@@ -146,7 +146,7 @@ module Google
       end
       
       def to_authorization
-        gem 'signet', '~> 0.4.0'
+        gem 'signet', '>= 0.4.0'
         require 'signet/oauth_2/client'
         # NOTE: Do not rely on this default value, as it may change
         new_authorization = Signet::OAuth2::Client.new


### PR DESCRIPTION
- Load automatically with a "require 'google/api_client'"
- Allow for signet >= 0.4.0
