### PR TITLE
Shutdown WEBrick server used in installed app flow

### DIFF
--- a/lib/google/api_client/auth/installed_app.rb
+++ b/lib/google/api_client/auth/installed_app.rb
@@ -92,9 +92,10 @@ module Google
           :Logger => WEBrick::Log.new(STDOUT, 0),
           :AccessLog => []
         )
-        trap("INT") { server.shutdown }
-        
-        server.mount_proc '/' do |req, res|
+        begin
+          trap("INT") { server.shutdown }
+
+          server.mount_proc '/' do |req, res|
             auth.code = req.query['code']
             if auth.code
               auth.fetch_access_token!
@@ -102,10 +103,13 @@ module Google
             res.status = WEBrick::HTTPStatus::RC_ACCEPTED
             res.body = RESPONSE_BODY
             server.stop
-        end
+          end
 
-        Launchy.open(auth.authorization_uri.to_s)
-        server.start
+          Launchy.open(auth.authorization_uri.to_s)
+          server.start
+        ensure
+          server.shutdown
+        end
         if @authorization.access_token
           if storage.respond_to?(:write_credentials)
             storage.write_credentials(@authorization)


### PR DESCRIPTION
Starting and stopping WEBrick only controls whether the event loop is
running, it does not start and stop listening on TCP sockets.
Our WEBrick server is starting to listen when it is initialised,
so we should ensure that we shut it down when we are done with it.

Note that shutdown is idempotent.
