### PR TITLE
Clarify google-api binary's --scope description

### DIFF
--- a/bin/google-api
+++ b/bin/google-api
@@ -58,7 +58,7 @@ module Google
           opts.separator "\nAvailable options:"
 
           opts.on(
-              "--scope <scope>", String, "Set the OAuth scope") do |s|
+              "--scope <scope>", String, "Set the OAuth scope(s), separated by spaces") do |s|
             options[:scope] = s
           end
           opts.on(


### PR DESCRIPTION
Makes it clear that multiple scopes are supported, and need to be space separated.
See https://github.com/google/google-api-ruby-client/issues/83
