### PR TITLE
Clarifies that `google-api oath-2-login` creates `~/.google-api.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ end
 Included with the gem is a command line interface for working with Google APIs.
 
 ```bash
-# Log in
+# Log in, storing auth tokens in ~/.google-api.yaml
 google-api oauth-2-login --client-id='...' --client-secret='...' --scope="https://www.googleapis.com/auth/plus.me"
 
-# List the signed-in user's activities
+# List the signed-in user's activities, using auth tokens in ~/.google-api.yaml
 google-api execute plus.activities.list --api=plus -- userId="me" collection="public"
 
 # Start an interactive API session

--- a/bin/google-api
+++ b/bin/google-api
@@ -242,6 +242,7 @@ module Google
             "access_token" => options[:access_token],
             "refresh_token" => options[:refresh_token]
           }
+          puts "Writing oauth_2 tokens to ~/.google-api.yaml"
           config_file = File.expand_path('~/.google-api.yaml')
           open(config_file, 'w') { |file| file.write(YAML.dump(config)) }
           exit(0)
@@ -263,6 +264,7 @@ module Google
               "access_token" => oauth_client.access_token,
               "refresh_token" => oauth_client.refresh_token
             }
+            puts "Writing oauth_2 tokens to ~/.google-api.yaml"
             config_file = File.expand_path('~/.google-api.yaml')
             open(config_file, 'w') { |file| file.write(YAML.dump(config)) }
           end


### PR DESCRIPTION
Also updates the relevant section of README.
