### PR TITLE
`:approval_prompt => force` option required for obtaining lost refresh_token as of Signet 0.5.1

### DIFF
--- a/lib/google/api_client/auth/installed_app.rb
+++ b/lib/google/api_client/auth/installed_app.rb
@@ -104,7 +104,7 @@ module Google
             server.stop
         end
 
-        Launchy.open(auth.authorization_uri(approval_prompt: "force").to_s)
+        Launchy.open(auth.authorization_uri(:approval_prompt => "force").to_s)
         server.start
         if @authorization.access_token
           if storage.respond_to?(:write_credentials)


### PR DESCRIPTION
[Signet](https://github.com/google/signet) 0.5.1 broke existing behaviour.
As of [v0.5.1](https://github.com/google/signet/blob/master/CHANGELOG.md), Signet no longer sets `approval_prompt` option to `:force`.

This change makes it so that refresh tokens are not re-obtainable. I found details about this written below.

From: https://developers.google.com/accounts/docs/OAuth2WebServer.

> Important: When your application receives a refresh token, it is important to store that refresh token for future use. If your application loses the refresh token, it will have to re-prompt the user for consent before obtaining another refresh token. If you need to re-prompt the user for consent, include the approval_prompt parameter in the authorization code request, and set the value to force.

I added some code to `Google::APIClient::InstalledAppFlow.authorize` to address this issue.
