### PR TITLE
Fix loading JSON credentials to use symbolized keys

### DIFF
--- a/lib/google/api_client/auth/file_storage.rb
+++ b/lib/google/api_client/auth/file_storage.rb
@@ -44,9 +44,9 @@ module Google
       def load_credentials
         if File.exist? self.path
           File.open(self.path, 'r') do |file|
-            cached_credentials = JSON.load(file)
+            cached_credentials = JSON.parse(file.read, symbolize_names: true)
             @authorization = Signet::OAuth2::Client.new(cached_credentials)
-            @authorization.issued_at = Time.at(cached_credentials['issued_at'])
+            @authorization.issued_at = Time.at(cached_credentials[:issued_at])
             if @authorization.expired?
               @authorization.fetch_access_token!
               self.write_credentials


### PR DESCRIPTION
`Addressable::URI` (in [Signet](https://github.com/google/signet/blob/master/lib/signet/oauth_2/client.rb#L276)) supports only Hash with symbolized keys.

The following error occurred when fetching access token with refresh token stored by FileStorage.

```
/path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/generic.rb:214:in `initialize': the scheme http does not accept registry part: :80 (or bad hostname?) (URI::InvalidURIError)
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/http.rb:84:in `initialize'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:214:in `new'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:214:in `parse'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:1232:in `URI'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:1029:in `proxy_uri'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:1016:in `proxy?'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:869:in `connect'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:863:in `do_start'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:852:in `start'
    from /path/to/.rbenv/versions/2.1.2/lib/ruby/2.1.0/net/http.rb:1369:in `request'
    from /path/to/src/google-api-client/vendor/bundle/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:80:in `perform_request'
    from /path/to/src/google-api-client/vendor/bundle/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:39:in `call'
    from /path/to/src/google-api-client/vendor/bundle/gems/faraday-0.9.0/lib/faraday/request/url_encoded.rb:15:in `call'
    from /path/to/src/google-api-client/vendor/bundle/gems/signet-0.5.1/lib/signet/oauth_2/client.rb:933:in `fetch_access_token'
    from /path/to/src/google-api-client/vendor/bundle/gems/signet-0.5.1/lib/signet/oauth_2/client.rb:956:in `fetch_access_token!'
    from /path/to/src/google-api-client/lib/google/api_client/auth/file_storage.rb:52:in `block in load_credentials'
    from /path/to/src/google-api-client/lib/google/api_client/auth/file_storage.rb:46:in `open'
    from /path/to/src/google-api-client/lib/google/api_client/auth/file_storage.rb:46:in `load_credentials'
    from /path/to/src/google-api-client/lib/google/api_client/auth/file_storage.rb:39:in `initialize'
```

This PR just fixes the error.
#100 also solves the error with [another approach](https://github.com/google/google-api-ruby-client/pull/100/files#diff-e412e1804c0537ad2f66c712b3393093R90) (URLs are always stored as String instead of Hash)
