### PR TITLE
Update README example for register_discovery_document

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ drive = client.discovered_api('drive', 'v2')
 Locally cached discovery documents may be used as well. To load an API from a local file:
 
 ```ruby
+# Output discovery document to JSON
+File.open('my-api.json', 'w') do |f| f.puts MultiJson.dump(client.discovery_document('myapi', 'v1')) end
+
+# Read discovery document and load API
 doc = File.read('my-api.json')
-my_api = client.register_discovery_document('myapi', 'v1', doc)
+client.register_discovery_document('myapi', 'v1', doc)
+my_api = client.discovered_api('myapi', 'v1')
 ```
 
 ### Authorization


### PR DESCRIPTION
Update README documentation for register_discovery_document (It returns a Hash instead of an API object, therefore we must call discovered_api to get the API object)
