### PR TITLE
Bump signet min version to allow impersonation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'signet', '>= 0.5.0'
+gem 'signet', '>= 0.5.1'
 gem 'addressable', '>= 2.3.2'
 gem 'uuidtools', '>= 2.1.0'
 gem 'autoparse', '>= 0.3.3'

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<signet>, [">= 0.5.0"])
+      s.add_runtime_dependency(%q<signet>, [">= 0.5.1"])
       s.add_runtime_dependency(%q<addressable>, [">= 2.3.2"])
       s.add_runtime_dependency(%q<uuidtools>, [">= 2.1.0"])
       s.add_runtime_dependency(%q<autoparse>, [">= 0.3.3"])
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, [">= 0.9.0"])
       s.add_development_dependency(%q<rspec>, [">= 2.11.0"])
     else
-      s.add_dependency(%q<signet>, [">= 0.5.0"])
+      s.add_dependency(%q<signet>, [">= 0.5.1"])
       s.add_dependency(%q<addressable>, [">= 2.3.2"])
       s.add_dependency(%q<uuidtools>, [">= 2.1.0"])
       s.add_dependency(%q<autoparse>, [">= 0.3.3"])
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rspec>, [">= 2.11.0"])
     end
   else
-    s.add_dependency(%q<signet>, [">= 0.5.0"])
+    s.add_dependency(%q<signet>, [">= 0.5.1"])
     s.add_dependency(%q<addressable>, [">= 2.3.2"])
     s.add_dependency(%q<uuidtools>, [">= 2.1.0"])
     s.add_dependency(%q<autoparse>, [">= 0.3.3"])


### PR DESCRIPTION
Commit https://github.com/google/signet/commit/0c6fedf5209bb4020777786a205c2ba36162da23
allowed the sub attribute which is necessary for domain restricted
authentication for service accounts.
