### PR TITLE
Update google-api-client.gemspec

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'launchy', '~> 2.4'
   s.add_runtime_dependency 'retriable', '~> 1.4'
-  s.add_runtime_dependency 'activesupport', '~> 3.2'
+  s.add_runtime_dependency 'activesupport', '>= 3.2'
   
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'yard', '~> 0.8'


### PR DESCRIPTION
with ~> 3.2 we will be able to use just AS 3.2.x. 
