### PR TITLE
Add Class SetThumbnailRequest

### DIFF
--- a/generated/google/apis/youtube_v3/classes.rb
+++ b/generated/google/apis/youtube_v3/classes.rb
@@ -6802,6 +6802,25 @@ module Google
       end
       
       # 
+      class SetThumbnailRequest
+        include Google::Apis::Core::Hashable
+
+        # Etag of this resource.
+        # Corresponds to the JSON property `video_id`
+        # @return [String]
+        attr_accessor :video_id
+
+        def initialize(**args)
+           update!(**args)
+        end
+
+        # Update properties of this object
+        def update!(**args)
+          @video_id = args[:video_id] if args.key?(:video_id)
+        end
+      end
+      
+      # 
       class SetThumbnailResponse
         include Google::Apis::Core::Hashable
       

--- a/generated/google/apis/youtube_v3/representations.rb
+++ b/generated/google/apis/youtube_v3/representations.rb
@@ -856,6 +856,12 @@ module Google
         include Google::Apis::Core::JsonObjectSupport
       end
       
+      class SetThumbnailRequest
+        class Representation < Google::Apis::Core::JsonRepresentation; end
+
+        include Google::Apis::Core::JsonObjectSupport
+      end
+      
       class SetThumbnailResponse
         class Representation < Google::Apis::Core::JsonRepresentation; end
       

--- a/generated/google/apis/youtube_v3/service.rb
+++ b/generated/google/apis/youtube_v3/service.rb
@@ -3662,6 +3662,8 @@ module Google
             command.upload_source = upload_source
             command.upload_content_type = content_type
           end
+          command.request_representation = Google::Apis::YoutubeV3::SetThumbnailRequest::Representation
+          command.request_object = { video_id: video_id }
           command.response_representation = Google::Apis::YoutubeV3::SetThumbnailResponse::Representation
           command.response_class = Google::Apis::YoutubeV3::SetThumbnailResponse
           command.query['onBehalfOfContentOwner'] = on_behalf_of_content_owner unless on_behalf_of_content_owner.nil?


### PR DESCRIPTION
Fixes: #606 

`Google::Apis::Core::HttpCommand.body` was `nil`.

before:
```
Upload complete
Sending upload start command to https://www.googleapis.com/upload/youtube/v3/thumbnails/set?
Upload status final
Error - #<Google::Apis::ClientError: required: Required parameter: videoId>
```

after:
```
Sending upload command to https://www.googleapis.com/upload/youtube/v3/thumbnails/set?videoId=55XDuvqq1wI&upload_id=AEnB2UqGyNrZjrGaJYvfYEi3POef6dzvNqjYwSAH7zgYRmBa8Uvqkx6nq3g1h2SWvUq9ef8eq4cFj5gIZXMX7WkGe_qE9CxKFA&upload_protocol=resumable
Upload status final
Success - #<Google::Apis::YoutubeV3::SetThumbnailResponse:0x00007f90a0f4f320
```