### PR TITLE
Fix comment to reflect 100,000 row request limit

### DIFF
--- a/generated/google/apis/analyticsreporting_v4/classes.rb
+++ b/generated/google/apis/analyticsreporting_v4/classes.rb
@@ -1031,7 +1031,7 @@ module Google
       
         # Page size is for paging and specifies the maximum number of returned rows.
         # Page size should be >= 0. A query returns the default of 1,000 rows.
-        # The Analytics Core Reporting API returns a maximum of 10,000 rows per
+        # The Analytics Core Reporting API returns a maximum of 100,000 rows per
         # request, no matter how many you ask for. It can also return fewer rows
         # than requested, if there aren't as many dimension segments as you expect.
         # For instance, there are fewer than 300 possible values for `ga:country`,


### PR DESCRIPTION
According to the documentation, the pageSize param has a maximum of 100,000. See `pageSize` at https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet.  I was able to make a request with > 10,000 rows, but was not able to test that the limit is capped at 100,000.