### PR TITLE
Add launchy to gemspec

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
+  spec.add_runtime_dependency 'launchy', '>= 2.1.1'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'activesupport', '>= 4.2', '< 5.1'
 end


### PR DESCRIPTION
Hi all.

This fix #537.

I think `launchy` should be included in gemspec.