### PR TITLE
Add Signet::UnexpectedStatusError

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
-  spec.add_runtime_dependency 'signet', '~> 0.9'
+  spec.add_runtime_dependency 'signet', '~> 0.10'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'

--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -99,7 +99,7 @@ module Google
               # NotFound, etc
               auth_tries = (try == 1 && authorization_refreshable? ? 2 : 1)
               Retriable.retriable tries: auth_tries,
-                                  on: [Google::Apis::AuthorizationError, Signet::AuthorizationError, Signet::RemoteServerError],
+                                  on: [Google::Apis::AuthorizationError, Signet::AuthorizationError, Signet::RemoteServerError, Signet::UnexpectedStatusError],
                                   on_retry: proc { |*| refresh_authorization } do
                 execute_once(client).tap do |result|
                   if block_given?


### PR DESCRIPTION
Similar to https://github.com/google/google-api-ruby-client/pull/707

As asked by @TheRoyalTnetennba in https://github.com/google/signet/pull/101

This PR adds the new `UnexpectedStatusError`