### PR TITLE
OpenCensus integration for outgoing requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
   gem 'rmail', '~> 1.1'
   gem 'redis', '~> 3.2'
   gem 'logging', '~> 2.2'
+  gem 'opencensus', '~> 0.3'
 end
 
 platforms :jruby do

--- a/lib/google/apis/options.rb
+++ b/lib/google/apis/options.rb
@@ -32,7 +32,8 @@ module Google
       :normalize_unicode,
       :skip_serialization,
       :skip_deserialization,
-      :api_format_version)
+      :api_format_version,
+      :use_opencensus)
 
     # General client options
     class ClientOptions
@@ -101,5 +102,6 @@ module Google
     RequestOptions.default.skip_serialization = false
     RequestOptions.default.skip_deserialization = false
     RequestOptions.default.api_format_version = nil
+    RequestOptions.default.use_opencensus = true
   end
 end


### PR DESCRIPTION
Add OpenCensus instrumentation for all outgoing HTTP requests.

If the OpenCensus gem is present, AND there is an OpenCensus span context present, AND OpenCensus instrumentation is enabled in the request options, then outgoing HTTP requests will be wrapped in an OpenCensus span. This will make OpenCensus "just work" by default for all outgoing Google API REST calls, if the application uses OpenCensus. At the same time, OpenCensus for these calls can be disabled in the RequestOptions. OpenCensus is *not* required, and this code has no effect if the OpenCensus gem is not present.

Currently, the URI of the API call is used as the span name.

/cc @bogdandrutu