### PR TITLE
Add custom inspect to Google::Apis:Error

### DIFF
--- a/lib/google/apis/errors.rb
+++ b/lib/google/apis/errors.rb
@@ -41,6 +41,15 @@ module Google
           super
         end
       end
+
+      def inspect
+        extra = ""
+        extra << " status_code: #{status_code.inspect}" unless status_code.nil?
+        extra << " header: #{header.inspect}"           unless header.nil?
+        extra << " body: #{body.inspect}"               unless body.nil?
+
+        "#<#{self.class.name}: #{message}#{extra}>"
+      end
     end
 
     # An error which is raised when there is an unexpected response or other


### PR DESCRIPTION
Add the `status_code`, `header`, and `body` values to `#inspect` when present. These values can help users understand why they are getting errors, but many users don't know to look for them. Adding the values to inspect should help discoverability.

This change turns this:

```
#<Google::Apis::ClientError: timeRangeEmpty: The specified time range is empty.>
```

into this:

```
#<Google::Apis::ClientError: timeRangeEmpty: The specified time range is empty. status_code: 400 header: #<HTTP::Message::Headers:0x00007fee7d0352f0 @http_version="1.1", @body_size=221, @chunked=false, @request_method="GET", @request_uri=#<Addressable::URI:0x3ff73ce68e80 URI:https://www.googleapis.com/zoo/animals?>, @request_query=nil, @request_absolute_uri=nil, @status_code=400, @reason_phrase="Bad Request", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=nil, @is_request=false, @header_item=[["Content-Type", "application/json"]], @dumped=false> body: "{\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"timeRangeEmpty\",\n    \"message\": \"The specified time range is empty.\"\n   }\n  ],\n  \"code\": 400,\n  \"message\": \"The specified time range is empty.\"\n }\n}\n">
```