### PR TITLE
Update googleauth dependency

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mime-types', '~> 3.0'
   spec.add_runtime_dependency 'signet', '~> 0.10'
-  spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.7.0'
+  spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.8.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'activesupport', '>= 4.2', '< 5.1'


### PR DESCRIPTION
Allow the dependency to use the 0.7.x releases.