### PR TITLE
Fix naming of monitoring.projects.timeSeries.create method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   gem 'rmail', '~> 1.1'
   gem 'redis', '~> 3.2'
   gem 'logging', '~> 2.2'
-  gem 'opencensus', '~> 0.3'
+  gem 'opencensus', '~> 0.4'
 end
 
 platforms :jruby do

--- a/spec/google/apis/core/http_command_spec.rb
+++ b/spec/google/apis/core/http_command_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe Google::Apis::Core::HttpCommand do
       OpenCensus::Trace.start_request_trace do |span_context|
         result = command.execute(client)
         expect(a_request(:get, 'https://www.googleapis.com/zoo/animals')
-          .with { |req| !req.headers['Trace-Context'].empty? }).to have_been_made
+          .with { |req| !req.headers['Traceparent'].empty? }).to have_been_made
       end
     end
 


### PR DESCRIPTION
Update the generated method name corresponding to `monitoring.projects.timeSeries.create` to `create_project_time_series`. This should fix the error that is currently causing Ruby codegen to break.

Currently, for some reason, the name map is mapping `monitoring.projects.timeSeries.create` to `create_time_series`, which is not the standard name normally generated for such a resource call. This is now breaking codegen because an update to the discovery doc introduced `monitoring.timeSeries.create`, which by default maps to `create_time_series`, resulting in a name conflict. This change reverts the mapping for `monitoring.projects.timeSeries.create` to the method name `create_project_time_series` that should normally be created for this call.

Despite the name change, this actually should _not_ be a breaking change. This is because the new discovery doc re-introduces `monitoring.timeSeries.create` which has the exact same usage as the older method. In other words, the old `create_time_series` gets renamed to `create_project_time_series`, but a new `create_time_series` with the same usage gets added to replace it.