### PR TITLE
Prevent errors loading deprecated installed_app file if launchy is not present

### DIFF
--- a/lib/google/api_client/auth/installed_app.rb
+++ b/lib/google/api_client/auth/installed_app.rb
@@ -13,13 +13,28 @@
 # limitations under the License.
 
 require 'webrick'
-require 'launchy'
+
+launchy_available =
+  begin
+    require 'launchy'
+    true
+  rescue LoadError
+    warn "Attempted to require google/api_client/auth/installed_app.rb when" \
+         " launchy is not available. The InstalledAppFlow class is disabled."
+    false
+  end
 
 module Google
   class APIClient
 
     # Small helper for the sample apps for performing OAuth 2.0 flows from the command
     # line or in any other installed app environment.
+    #
+    # This class is used in some sample apps and tests but is not really part
+    # of the client libraries, and probably does not belong here. As such, it
+    # is deprecated. If you do choose to use it, note that you must include the
+    # `launchy` gem in your bundle, as it is required by this class but not
+    # listed in the google-api-client gem's requirements.
     #
     # @example
     #
@@ -125,4 +140,4 @@ module Google
     end
 
   end
-end
+end if launchy_available


### PR DESCRIPTION
Fixes #537

The `installed_app.rb` file is not really part of the library and arguably doesn't belong here. It is correctly deprecated. However, if it is loaded (possibly as a result of being eagerly loaded by ActiveSupport), and the `launchy` gem (which is not listed as a gem dependency so is not generally brought into user bundles) is not present, the file will crash with a `LoadError`.

So we do two things.
* Rescue the `LoadError` that results from `launchy` not being present, warn the user what has taken place, and bail from loading the rest of the file. This will let applications that use `eager_load` use the gem without having to include `launchy` in their bundle explicitly.
* Document the `launchy` dependency in case someone actually wants to use this (deprecated) class.