### PR TITLE
Update Rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem 'webmock', '~> 2.1'
   gem 'simplecov', '~> 0.12'
   gem 'coveralls', '~> 0.8'
-  gem 'rubocop', '~> 0.42.0'
+  gem 'rubocop', '~> 0.49.0'
   gem 'launchy', '~> 2.4'
   gem 'dotenv', '~> 2.0'
   gem 'fakefs', '~> 0.6', require: "fakefs/safe"


### PR DESCRIPTION
Update version to address [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-8418).