### PR TITLE
Change logged representation of certain classes

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -253,7 +253,7 @@ module Google
         # @return [Object] result if no block given
         # @yield [result, nil] if block given
         def success(result, &block)
-          logger.debug { sprintf('Success - %s', safe_object_representation(result) }
+          logger.debug { sprintf('Success - %s', safe_object_representation(result)) }
           block.call(result, nil) if block_given?
           result
         end

--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -253,7 +253,7 @@ module Google
         # @return [Object] result if no block given
         # @yield [result, nil] if block given
         def success(result, &block)
-          logger.debug { sprintf('Success - %s', PP.pp(result, '')) }
+          logger.debug { sprintf('Success - %s', safe_object_representation(result) }
           block.call(result, nil) if block_given?
           result
         end
@@ -332,6 +332,19 @@ module Google
         end
 
         private
+
+        UNSAFE_CLASS_NAMES = [
+          "Google::Apis::CloudkmsV1::DecryptResponse"
+        ]
+
+        def safe_object_representation obj
+          name = obj.class.name
+          if UNSAFE_CLASS_NAMES.include? name
+            "#<#{name} (fields redacted)>"
+          else
+            PP.pp(obj, "")
+          end
+        end
 
         def opencensus_begin_span
           return unless OPENCENSUS_AVAILABLE && options.use_opencensus

--- a/spec/google/apis/core/http_command_spec.rb
+++ b/spec/google/apis/core/http_command_spec.rb
@@ -15,6 +15,15 @@
 require 'spec_helper'
 require 'google/apis/core/http_command'
 
+module Google
+  module Apis
+    module CloudkmsV1
+      class DecryptResponse
+      end
+    end
+  end
+end
+
 RSpec.describe Google::Apis::Core::HttpCommand do
   include TestHelpers
   include_context 'HTTP client'
@@ -429,4 +438,23 @@ RSpec.describe Google::Apis::Core::HttpCommand do
     command.execute(client)
   end
 
+  describe "#safe_object_representation" do
+    let(:command) do
+      Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
+    end
+
+    it "should show fields in a normal object" do
+      obj = Object.new
+      obj.instance_variable_set(:@foobar, "hi")
+      str = command.send(:safe_object_representation, obj)
+      expect(str).to match /@foobar/
+    end
+
+    it "should not show fields in a restricted object" do
+      obj = Google::Apis::CloudkmsV1::DecryptResponse.new
+      obj.instance_variable_set(:@foobar, "hi")
+      str = command.send(:safe_object_representation, obj)
+      expect(str).not_to match /@foobar/
+    end
+  end
 end


### PR DESCRIPTION
Change logged representation of the `Google::Apis::CloudkmsV1::DecryptResponse` class to remove all field data from the logged string.