### PR TITLE
bump copyright and add 2.6 to list of tested ruby versions

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -20,7 +20,7 @@ ruby --version
 # https://github.com/bundler/bundler/issues/6154
 export BUNDLE_GEMFILE=
 
-RUBY_VERSIONS=("2.3.8" "2.4.5" "2.5.3")
+RUBY_VERSIONS=("2.3.8" "2.4.5" "2.5.3" "2.6.0")
 
 # Capture failures
 EXIT_STATUS=0 # everything passed

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/abusiveexperiencereport_v1.rb
+++ b/generated/google/apis/abusiveexperiencereport_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/abusiveexperiencereport_v1/classes.rb
+++ b/generated/google/apis/abusiveexperiencereport_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/abusiveexperiencereport_v1/representations.rb
+++ b/generated/google/apis/abusiveexperiencereport_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/abusiveexperiencereport_v1/service.rb
+++ b/generated/google/apis/abusiveexperiencereport_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/acceleratedmobilepageurl_v1.rb
+++ b/generated/google/apis/acceleratedmobilepageurl_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/acceleratedmobilepageurl_v1/classes.rb
+++ b/generated/google/apis/acceleratedmobilepageurl_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/acceleratedmobilepageurl_v1/representations.rb
+++ b/generated/google/apis/acceleratedmobilepageurl_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/acceleratedmobilepageurl_v1/service.rb
+++ b/generated/google/apis/acceleratedmobilepageurl_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/accesscontextmanager_v1beta.rb
+++ b/generated/google/apis/accesscontextmanager_v1beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/accesscontextmanager_v1beta/classes.rb
+++ b/generated/google/apis/accesscontextmanager_v1beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/accesscontextmanager_v1beta/representations.rb
+++ b/generated/google/apis/accesscontextmanager_v1beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/accesscontextmanager_v1beta/service.rb
+++ b/generated/google/apis/accesscontextmanager_v1beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer2_v2beta1.rb
+++ b/generated/google/apis/adexchangebuyer2_v2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer2_v2beta1/classes.rb
+++ b/generated/google/apis/adexchangebuyer2_v2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer2_v2beta1/representations.rb
+++ b/generated/google/apis/adexchangebuyer2_v2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer2_v2beta1/service.rb
+++ b/generated/google/apis/adexchangebuyer2_v2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_2.rb
+++ b/generated/google/apis/adexchangebuyer_v1_2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_2/classes.rb
+++ b/generated/google/apis/adexchangebuyer_v1_2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_2/representations.rb
+++ b/generated/google/apis/adexchangebuyer_v1_2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_2/service.rb
+++ b/generated/google/apis/adexchangebuyer_v1_2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_3.rb
+++ b/generated/google/apis/adexchangebuyer_v1_3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_3/classes.rb
+++ b/generated/google/apis/adexchangebuyer_v1_3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_3/representations.rb
+++ b/generated/google/apis/adexchangebuyer_v1_3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_3/service.rb
+++ b/generated/google/apis/adexchangebuyer_v1_3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_4.rb
+++ b/generated/google/apis/adexchangebuyer_v1_4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_4/classes.rb
+++ b/generated/google/apis/adexchangebuyer_v1_4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_4/representations.rb
+++ b/generated/google/apis/adexchangebuyer_v1_4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexchangebuyer_v1_4/service.rb
+++ b/generated/google/apis/adexchangebuyer_v1_4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexperiencereport_v1.rb
+++ b/generated/google/apis/adexperiencereport_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexperiencereport_v1/classes.rb
+++ b/generated/google/apis/adexperiencereport_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexperiencereport_v1/representations.rb
+++ b/generated/google/apis/adexperiencereport_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adexperiencereport_v1/service.rb
+++ b/generated/google/apis/adexperiencereport_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_datatransfer_v1.rb
+++ b/generated/google/apis/admin_datatransfer_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_datatransfer_v1/classes.rb
+++ b/generated/google/apis/admin_datatransfer_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_datatransfer_v1/representations.rb
+++ b/generated/google/apis/admin_datatransfer_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_datatransfer_v1/service.rb
+++ b/generated/google/apis/admin_datatransfer_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_directory_v1.rb
+++ b/generated/google/apis/admin_directory_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_directory_v1/classes.rb
+++ b/generated/google/apis/admin_directory_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_directory_v1/representations.rb
+++ b/generated/google/apis/admin_directory_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_directory_v1/service.rb
+++ b/generated/google/apis/admin_directory_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_reports_v1.rb
+++ b/generated/google/apis/admin_reports_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_reports_v1/classes.rb
+++ b/generated/google/apis/admin_reports_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_reports_v1/representations.rb
+++ b/generated/google/apis/admin_reports_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/admin_reports_v1/service.rb
+++ b/generated/google/apis/admin_reports_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsense_v1_4.rb
+++ b/generated/google/apis/adsense_v1_4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsense_v1_4/classes.rb
+++ b/generated/google/apis/adsense_v1_4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsense_v1_4/representations.rb
+++ b/generated/google/apis/adsense_v1_4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsense_v1_4/service.rb
+++ b/generated/google/apis/adsense_v1_4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsensehost_v4_1.rb
+++ b/generated/google/apis/adsensehost_v4_1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsensehost_v4_1/classes.rb
+++ b/generated/google/apis/adsensehost_v4_1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsensehost_v4_1/representations.rb
+++ b/generated/google/apis/adsensehost_v4_1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/adsensehost_v4_1/service.rb
+++ b/generated/google/apis/adsensehost_v4_1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/alertcenter_v1beta1.rb
+++ b/generated/google/apis/alertcenter_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/alertcenter_v1beta1/classes.rb
+++ b/generated/google/apis/alertcenter_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/alertcenter_v1beta1/representations.rb
+++ b/generated/google/apis/alertcenter_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/alertcenter_v1beta1/service.rb
+++ b/generated/google/apis/alertcenter_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v2_4.rb
+++ b/generated/google/apis/analytics_v2_4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v2_4/classes.rb
+++ b/generated/google/apis/analytics_v2_4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v2_4/representations.rb
+++ b/generated/google/apis/analytics_v2_4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v2_4/service.rb
+++ b/generated/google/apis/analytics_v2_4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v3.rb
+++ b/generated/google/apis/analytics_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v3/classes.rb
+++ b/generated/google/apis/analytics_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v3/representations.rb
+++ b/generated/google/apis/analytics_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analytics_v3/service.rb
+++ b/generated/google/apis/analytics_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analyticsreporting_v4.rb
+++ b/generated/google/apis/analyticsreporting_v4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analyticsreporting_v4/classes.rb
+++ b/generated/google/apis/analyticsreporting_v4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analyticsreporting_v4/representations.rb
+++ b/generated/google/apis/analyticsreporting_v4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/analyticsreporting_v4/service.rb
+++ b/generated/google/apis/analyticsreporting_v4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androiddeviceprovisioning_v1.rb
+++ b/generated/google/apis/androiddeviceprovisioning_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androiddeviceprovisioning_v1/classes.rb
+++ b/generated/google/apis/androiddeviceprovisioning_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androiddeviceprovisioning_v1/representations.rb
+++ b/generated/google/apis/androiddeviceprovisioning_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androiddeviceprovisioning_v1/service.rb
+++ b/generated/google/apis/androiddeviceprovisioning_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidenterprise_v1.rb
+++ b/generated/google/apis/androidenterprise_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidenterprise_v1/classes.rb
+++ b/generated/google/apis/androidenterprise_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidenterprise_v1/representations.rb
+++ b/generated/google/apis/androidenterprise_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidenterprise_v1/service.rb
+++ b/generated/google/apis/androidenterprise_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidmanagement_v1.rb
+++ b/generated/google/apis/androidmanagement_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidmanagement_v1/classes.rb
+++ b/generated/google/apis/androidmanagement_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidmanagement_v1/representations.rb
+++ b/generated/google/apis/androidmanagement_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidmanagement_v1/service.rb
+++ b/generated/google/apis/androidmanagement_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1.rb
+++ b/generated/google/apis/androidpublisher_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1/classes.rb
+++ b/generated/google/apis/androidpublisher_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1/representations.rb
+++ b/generated/google/apis/androidpublisher_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1/service.rb
+++ b/generated/google/apis/androidpublisher_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1_1.rb
+++ b/generated/google/apis/androidpublisher_v1_1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1_1/classes.rb
+++ b/generated/google/apis/androidpublisher_v1_1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1_1/representations.rb
+++ b/generated/google/apis/androidpublisher_v1_1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v1_1/service.rb
+++ b/generated/google/apis/androidpublisher_v1_1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v2.rb
+++ b/generated/google/apis/androidpublisher_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v2/classes.rb
+++ b/generated/google/apis/androidpublisher_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v2/representations.rb
+++ b/generated/google/apis/androidpublisher_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v2/service.rb
+++ b/generated/google/apis/androidpublisher_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v3.rb
+++ b/generated/google/apis/androidpublisher_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v3/classes.rb
+++ b/generated/google/apis/androidpublisher_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v3/representations.rb
+++ b/generated/google/apis/androidpublisher_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/androidpublisher_v3/service.rb
+++ b/generated/google/apis/androidpublisher_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1.rb
+++ b/generated/google/apis/appengine_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1/classes.rb
+++ b/generated/google/apis/appengine_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1/representations.rb
+++ b/generated/google/apis/appengine_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1/service.rb
+++ b/generated/google/apis/appengine_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1alpha.rb
+++ b/generated/google/apis/appengine_v1alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1alpha/classes.rb
+++ b/generated/google/apis/appengine_v1alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1alpha/representations.rb
+++ b/generated/google/apis/appengine_v1alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1alpha/service.rb
+++ b/generated/google/apis/appengine_v1alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta.rb
+++ b/generated/google/apis/appengine_v1beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta/classes.rb
+++ b/generated/google/apis/appengine_v1beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta/representations.rb
+++ b/generated/google/apis/appengine_v1beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta/service.rb
+++ b/generated/google/apis/appengine_v1beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta4.rb
+++ b/generated/google/apis/appengine_v1beta4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta4/classes.rb
+++ b/generated/google/apis/appengine_v1beta4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta4/representations.rb
+++ b/generated/google/apis/appengine_v1beta4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta4/service.rb
+++ b/generated/google/apis/appengine_v1beta4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta5.rb
+++ b/generated/google/apis/appengine_v1beta5.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta5/classes.rb
+++ b/generated/google/apis/appengine_v1beta5/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta5/representations.rb
+++ b/generated/google/apis/appengine_v1beta5/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appengine_v1beta5/service.rb
+++ b/generated/google/apis/appengine_v1beta5/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsactivity_v1.rb
+++ b/generated/google/apis/appsactivity_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsactivity_v1/classes.rb
+++ b/generated/google/apis/appsactivity_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsactivity_v1/representations.rb
+++ b/generated/google/apis/appsactivity_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsactivity_v1/service.rb
+++ b/generated/google/apis/appsactivity_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsmarket_v2.rb
+++ b/generated/google/apis/appsmarket_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsmarket_v2/classes.rb
+++ b/generated/google/apis/appsmarket_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsmarket_v2/representations.rb
+++ b/generated/google/apis/appsmarket_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appsmarket_v2/service.rb
+++ b/generated/google/apis/appsmarket_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appstate_v1.rb
+++ b/generated/google/apis/appstate_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appstate_v1/classes.rb
+++ b/generated/google/apis/appstate_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appstate_v1/representations.rb
+++ b/generated/google/apis/appstate_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/appstate_v1/service.rb
+++ b/generated/google/apis/appstate_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquery_v2.rb
+++ b/generated/google/apis/bigquery_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquery_v2/classes.rb
+++ b/generated/google/apis/bigquery_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquery_v2/representations.rb
+++ b/generated/google/apis/bigquery_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquery_v2/service.rb
+++ b/generated/google/apis/bigquery_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquerydatatransfer_v1.rb
+++ b/generated/google/apis/bigquerydatatransfer_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquerydatatransfer_v1/classes.rb
+++ b/generated/google/apis/bigquerydatatransfer_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquerydatatransfer_v1/representations.rb
+++ b/generated/google/apis/bigquerydatatransfer_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigquerydatatransfer_v1/service.rb
+++ b/generated/google/apis/bigquerydatatransfer_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigtableadmin_v2.rb
+++ b/generated/google/apis/bigtableadmin_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigtableadmin_v2/classes.rb
+++ b/generated/google/apis/bigtableadmin_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigtableadmin_v2/representations.rb
+++ b/generated/google/apis/bigtableadmin_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/bigtableadmin_v2/service.rb
+++ b/generated/google/apis/bigtableadmin_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/binaryauthorization_v1beta1.rb
+++ b/generated/google/apis/binaryauthorization_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/binaryauthorization_v1beta1/classes.rb
+++ b/generated/google/apis/binaryauthorization_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/binaryauthorization_v1beta1/representations.rb
+++ b/generated/google/apis/binaryauthorization_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/binaryauthorization_v1beta1/service.rb
+++ b/generated/google/apis/binaryauthorization_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v2.rb
+++ b/generated/google/apis/blogger_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v2/classes.rb
+++ b/generated/google/apis/blogger_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v2/representations.rb
+++ b/generated/google/apis/blogger_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v2/service.rb
+++ b/generated/google/apis/blogger_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v3.rb
+++ b/generated/google/apis/blogger_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v3/classes.rb
+++ b/generated/google/apis/blogger_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v3/representations.rb
+++ b/generated/google/apis/blogger_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/blogger_v3/service.rb
+++ b/generated/google/apis/blogger_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/books_v1.rb
+++ b/generated/google/apis/books_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/books_v1/classes.rb
+++ b/generated/google/apis/books_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/books_v1/representations.rb
+++ b/generated/google/apis/books_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/books_v1/service.rb
+++ b/generated/google/apis/books_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/calendar_v3.rb
+++ b/generated/google/apis/calendar_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/calendar_v3/classes.rb
+++ b/generated/google/apis/calendar_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/calendar_v3/representations.rb
+++ b/generated/google/apis/calendar_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/calendar_v3/service.rb
+++ b/generated/google/apis/calendar_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/chat_v1.rb
+++ b/generated/google/apis/chat_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/chat_v1/classes.rb
+++ b/generated/google/apis/chat_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/chat_v1/representations.rb
+++ b/generated/google/apis/chat_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/chat_v1/service.rb
+++ b/generated/google/apis/chat_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/civicinfo_v2.rb
+++ b/generated/google/apis/civicinfo_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/civicinfo_v2/classes.rb
+++ b/generated/google/apis/civicinfo_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/civicinfo_v2/representations.rb
+++ b/generated/google/apis/civicinfo_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/civicinfo_v2/service.rb
+++ b/generated/google/apis/civicinfo_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/classroom_v1.rb
+++ b/generated/google/apis/classroom_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/classroom_v1/classes.rb
+++ b/generated/google/apis/classroom_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/classroom_v1/representations.rb
+++ b/generated/google/apis/classroom_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/classroom_v1/service.rb
+++ b/generated/google/apis/classroom_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudasset_v1beta1.rb
+++ b/generated/google/apis/cloudasset_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudasset_v1beta1/classes.rb
+++ b/generated/google/apis/cloudasset_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudasset_v1beta1/representations.rb
+++ b/generated/google/apis/cloudasset_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudasset_v1beta1/service.rb
+++ b/generated/google/apis/cloudasset_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbilling_v1.rb
+++ b/generated/google/apis/cloudbilling_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbilling_v1/classes.rb
+++ b/generated/google/apis/cloudbilling_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbilling_v1/representations.rb
+++ b/generated/google/apis/cloudbilling_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbilling_v1/service.rb
+++ b/generated/google/apis/cloudbilling_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1.rb
+++ b/generated/google/apis/cloudbuild_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1/classes.rb
+++ b/generated/google/apis/cloudbuild_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1/representations.rb
+++ b/generated/google/apis/cloudbuild_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1/service.rb
+++ b/generated/google/apis/cloudbuild_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1alpha1.rb
+++ b/generated/google/apis/cloudbuild_v1alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1alpha1/classes.rb
+++ b/generated/google/apis/cloudbuild_v1alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1alpha1/representations.rb
+++ b/generated/google/apis/cloudbuild_v1alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudbuild_v1alpha1/service.rb
+++ b/generated/google/apis/cloudbuild_v1alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouddebugger_v2.rb
+++ b/generated/google/apis/clouddebugger_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouddebugger_v2/classes.rb
+++ b/generated/google/apis/clouddebugger_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouddebugger_v2/representations.rb
+++ b/generated/google/apis/clouddebugger_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouddebugger_v2/service.rb
+++ b/generated/google/apis/clouddebugger_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouderrorreporting_v1beta1.rb
+++ b/generated/google/apis/clouderrorreporting_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouderrorreporting_v1beta1/classes.rb
+++ b/generated/google/apis/clouderrorreporting_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouderrorreporting_v1beta1/representations.rb
+++ b/generated/google/apis/clouderrorreporting_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/clouderrorreporting_v1beta1/service.rb
+++ b/generated/google/apis/clouderrorreporting_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1.rb
+++ b/generated/google/apis/cloudfunctions_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1/classes.rb
+++ b/generated/google/apis/cloudfunctions_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1/representations.rb
+++ b/generated/google/apis/cloudfunctions_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1/service.rb
+++ b/generated/google/apis/cloudfunctions_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1beta2.rb
+++ b/generated/google/apis/cloudfunctions_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1beta2/classes.rb
+++ b/generated/google/apis/cloudfunctions_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1beta2/representations.rb
+++ b/generated/google/apis/cloudfunctions_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudfunctions_v1beta2/service.rb
+++ b/generated/google/apis/cloudfunctions_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1.rb
+++ b/generated/google/apis/cloudidentity_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1/classes.rb
+++ b/generated/google/apis/cloudidentity_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1/representations.rb
+++ b/generated/google/apis/cloudidentity_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1/service.rb
+++ b/generated/google/apis/cloudidentity_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1beta1.rb
+++ b/generated/google/apis/cloudidentity_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1beta1/classes.rb
+++ b/generated/google/apis/cloudidentity_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1beta1/representations.rb
+++ b/generated/google/apis/cloudidentity_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudidentity_v1beta1/service.rb
+++ b/generated/google/apis/cloudidentity_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudiot_v1.rb
+++ b/generated/google/apis/cloudiot_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudiot_v1/classes.rb
+++ b/generated/google/apis/cloudiot_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudiot_v1/representations.rb
+++ b/generated/google/apis/cloudiot_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudiot_v1/service.rb
+++ b/generated/google/apis/cloudiot_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudkms_v1.rb
+++ b/generated/google/apis/cloudkms_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudkms_v1/classes.rb
+++ b/generated/google/apis/cloudkms_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudkms_v1/representations.rb
+++ b/generated/google/apis/cloudkms_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudkms_v1/service.rb
+++ b/generated/google/apis/cloudkms_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudprofiler_v2.rb
+++ b/generated/google/apis/cloudprofiler_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudprofiler_v2/classes.rb
+++ b/generated/google/apis/cloudprofiler_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudprofiler_v2/representations.rb
+++ b/generated/google/apis/cloudprofiler_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudprofiler_v2/service.rb
+++ b/generated/google/apis/cloudprofiler_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1.rb
+++ b/generated/google/apis/cloudresourcemanager_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1/classes.rb
+++ b/generated/google/apis/cloudresourcemanager_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1/representations.rb
+++ b/generated/google/apis/cloudresourcemanager_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1/service.rb
+++ b/generated/google/apis/cloudresourcemanager_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1beta1.rb
+++ b/generated/google/apis/cloudresourcemanager_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1beta1/classes.rb
+++ b/generated/google/apis/cloudresourcemanager_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1beta1/representations.rb
+++ b/generated/google/apis/cloudresourcemanager_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v1beta1/service.rb
+++ b/generated/google/apis/cloudresourcemanager_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2.rb
+++ b/generated/google/apis/cloudresourcemanager_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2/classes.rb
+++ b/generated/google/apis/cloudresourcemanager_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2/representations.rb
+++ b/generated/google/apis/cloudresourcemanager_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2/service.rb
+++ b/generated/google/apis/cloudresourcemanager_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2beta1.rb
+++ b/generated/google/apis/cloudresourcemanager_v2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2beta1/classes.rb
+++ b/generated/google/apis/cloudresourcemanager_v2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2beta1/representations.rb
+++ b/generated/google/apis/cloudresourcemanager_v2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudresourcemanager_v2beta1/service.rb
+++ b/generated/google/apis/cloudresourcemanager_v2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudscheduler_v1beta1.rb
+++ b/generated/google/apis/cloudscheduler_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudscheduler_v1beta1/classes.rb
+++ b/generated/google/apis/cloudscheduler_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudscheduler_v1beta1/representations.rb
+++ b/generated/google/apis/cloudscheduler_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudscheduler_v1beta1/service.rb
+++ b/generated/google/apis/cloudscheduler_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudsearch_v1.rb
+++ b/generated/google/apis/cloudsearch_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudsearch_v1/classes.rb
+++ b/generated/google/apis/cloudsearch_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudsearch_v1/representations.rb
+++ b/generated/google/apis/cloudsearch_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudsearch_v1/service.rb
+++ b/generated/google/apis/cloudsearch_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1.rb
+++ b/generated/google/apis/cloudshell_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1/classes.rb
+++ b/generated/google/apis/cloudshell_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1/representations.rb
+++ b/generated/google/apis/cloudshell_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1/service.rb
+++ b/generated/google/apis/cloudshell_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1alpha1.rb
+++ b/generated/google/apis/cloudshell_v1alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1alpha1/classes.rb
+++ b/generated/google/apis/cloudshell_v1alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1alpha1/representations.rb
+++ b/generated/google/apis/cloudshell_v1alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudshell_v1alpha1/service.rb
+++ b/generated/google/apis/cloudshell_v1alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta2.rb
+++ b/generated/google/apis/cloudtasks_v2beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta2/classes.rb
+++ b/generated/google/apis/cloudtasks_v2beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta2/representations.rb
+++ b/generated/google/apis/cloudtasks_v2beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta2/service.rb
+++ b/generated/google/apis/cloudtasks_v2beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta3.rb
+++ b/generated/google/apis/cloudtasks_v2beta3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta3/classes.rb
+++ b/generated/google/apis/cloudtasks_v2beta3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta3/representations.rb
+++ b/generated/google/apis/cloudtasks_v2beta3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtasks_v2beta3/service.rb
+++ b/generated/google/apis/cloudtasks_v2beta3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v1.rb
+++ b/generated/google/apis/cloudtrace_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v1/classes.rb
+++ b/generated/google/apis/cloudtrace_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v1/representations.rb
+++ b/generated/google/apis/cloudtrace_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v1/service.rb
+++ b/generated/google/apis/cloudtrace_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v2.rb
+++ b/generated/google/apis/cloudtrace_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v2/classes.rb
+++ b/generated/google/apis/cloudtrace_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v2/representations.rb
+++ b/generated/google/apis/cloudtrace_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/cloudtrace_v2/service.rb
+++ b/generated/google/apis/cloudtrace_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1.rb
+++ b/generated/google/apis/composer_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1/classes.rb
+++ b/generated/google/apis/composer_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1/representations.rb
+++ b/generated/google/apis/composer_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1/service.rb
+++ b/generated/google/apis/composer_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1beta1.rb
+++ b/generated/google/apis/composer_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1beta1/classes.rb
+++ b/generated/google/apis/composer_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1beta1/representations.rb
+++ b/generated/google/apis/composer_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/composer_v1beta1/service.rb
+++ b/generated/google/apis/composer_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_alpha.rb
+++ b/generated/google/apis/compute_alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_alpha/classes.rb
+++ b/generated/google/apis/compute_alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_alpha/representations.rb
+++ b/generated/google/apis/compute_alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_alpha/service.rb
+++ b/generated/google/apis/compute_alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_beta.rb
+++ b/generated/google/apis/compute_beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_beta/classes.rb
+++ b/generated/google/apis/compute_beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_beta/representations.rb
+++ b/generated/google/apis/compute_beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_beta/service.rb
+++ b/generated/google/apis/compute_beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_v1.rb
+++ b/generated/google/apis/compute_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_v1/classes.rb
+++ b/generated/google/apis/compute_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_v1/representations.rb
+++ b/generated/google/apis/compute_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/compute_v1/service.rb
+++ b/generated/google/apis/compute_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1.rb
+++ b/generated/google/apis/container_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1/classes.rb
+++ b/generated/google/apis/container_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1/representations.rb
+++ b/generated/google/apis/container_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1/service.rb
+++ b/generated/google/apis/container_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1beta1.rb
+++ b/generated/google/apis/container_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1beta1/classes.rb
+++ b/generated/google/apis/container_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1beta1/representations.rb
+++ b/generated/google/apis/container_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/container_v1beta1/service.rb
+++ b/generated/google/apis/container_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1alpha1.rb
+++ b/generated/google/apis/containeranalysis_v1alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1alpha1/classes.rb
+++ b/generated/google/apis/containeranalysis_v1alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1alpha1/representations.rb
+++ b/generated/google/apis/containeranalysis_v1alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1alpha1/service.rb
+++ b/generated/google/apis/containeranalysis_v1alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1beta1.rb
+++ b/generated/google/apis/containeranalysis_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1beta1/classes.rb
+++ b/generated/google/apis/containeranalysis_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1beta1/representations.rb
+++ b/generated/google/apis/containeranalysis_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/containeranalysis_v1beta1/service.rb
+++ b/generated/google/apis/containeranalysis_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2.rb
+++ b/generated/google/apis/content_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2/classes.rb
+++ b/generated/google/apis/content_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2/representations.rb
+++ b/generated/google/apis/content_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2/service.rb
+++ b/generated/google/apis/content_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2_1.rb
+++ b/generated/google/apis/content_v2_1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2_1/classes.rb
+++ b/generated/google/apis/content_v2_1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2_1/representations.rb
+++ b/generated/google/apis/content_v2_1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/content_v2_1/service.rb
+++ b/generated/google/apis/content_v2_1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/customsearch_v1.rb
+++ b/generated/google/apis/customsearch_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/customsearch_v1/classes.rb
+++ b/generated/google/apis/customsearch_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/customsearch_v1/representations.rb
+++ b/generated/google/apis/customsearch_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/customsearch_v1/service.rb
+++ b/generated/google/apis/customsearch_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataflow_v1b3.rb
+++ b/generated/google/apis/dataflow_v1b3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataflow_v1b3/classes.rb
+++ b/generated/google/apis/dataflow_v1b3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataflow_v1b3/representations.rb
+++ b/generated/google/apis/dataflow_v1b3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataflow_v1b3/service.rb
+++ b/generated/google/apis/dataflow_v1b3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1.rb
+++ b/generated/google/apis/dataproc_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1/classes.rb
+++ b/generated/google/apis/dataproc_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1/representations.rb
+++ b/generated/google/apis/dataproc_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1/service.rb
+++ b/generated/google/apis/dataproc_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1beta2.rb
+++ b/generated/google/apis/dataproc_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1beta2/classes.rb
+++ b/generated/google/apis/dataproc_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1beta2/representations.rb
+++ b/generated/google/apis/dataproc_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dataproc_v1beta2/service.rb
+++ b/generated/google/apis/dataproc_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1.rb
+++ b/generated/google/apis/datastore_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1/classes.rb
+++ b/generated/google/apis/datastore_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1/representations.rb
+++ b/generated/google/apis/datastore_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1/service.rb
+++ b/generated/google/apis/datastore_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta1.rb
+++ b/generated/google/apis/datastore_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta1/classes.rb
+++ b/generated/google/apis/datastore_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta1/representations.rb
+++ b/generated/google/apis/datastore_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta1/service.rb
+++ b/generated/google/apis/datastore_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta3.rb
+++ b/generated/google/apis/datastore_v1beta3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta3/classes.rb
+++ b/generated/google/apis/datastore_v1beta3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta3/representations.rb
+++ b/generated/google/apis/datastore_v1beta3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/datastore_v1beta3/service.rb
+++ b/generated/google/apis/datastore_v1beta3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_alpha.rb
+++ b/generated/google/apis/deploymentmanager_alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_alpha/classes.rb
+++ b/generated/google/apis/deploymentmanager_alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_alpha/representations.rb
+++ b/generated/google/apis/deploymentmanager_alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_alpha/service.rb
+++ b/generated/google/apis/deploymentmanager_alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2.rb
+++ b/generated/google/apis/deploymentmanager_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2/classes.rb
+++ b/generated/google/apis/deploymentmanager_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2/representations.rb
+++ b/generated/google/apis/deploymentmanager_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2/service.rb
+++ b/generated/google/apis/deploymentmanager_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2beta.rb
+++ b/generated/google/apis/deploymentmanager_v2beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2beta/classes.rb
+++ b/generated/google/apis/deploymentmanager_v2beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2beta/representations.rb
+++ b/generated/google/apis/deploymentmanager_v2beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/deploymentmanager_v2beta/service.rb
+++ b/generated/google/apis/deploymentmanager_v2beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_1.rb
+++ b/generated/google/apis/dfareporting_v3_1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_1/classes.rb
+++ b/generated/google/apis/dfareporting_v3_1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_1/representations.rb
+++ b/generated/google/apis/dfareporting_v3_1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_1/service.rb
+++ b/generated/google/apis/dfareporting_v3_1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_2.rb
+++ b/generated/google/apis/dfareporting_v3_2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_2/classes.rb
+++ b/generated/google/apis/dfareporting_v3_2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_2/representations.rb
+++ b/generated/google/apis/dfareporting_v3_2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dfareporting_v3_2/service.rb
+++ b/generated/google/apis/dfareporting_v3_2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2.rb
+++ b/generated/google/apis/dialogflow_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2/classes.rb
+++ b/generated/google/apis/dialogflow_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2/representations.rb
+++ b/generated/google/apis/dialogflow_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2/service.rb
+++ b/generated/google/apis/dialogflow_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2beta1.rb
+++ b/generated/google/apis/dialogflow_v2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2beta1/classes.rb
+++ b/generated/google/apis/dialogflow_v2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2beta1/representations.rb
+++ b/generated/google/apis/dialogflow_v2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dialogflow_v2beta1/service.rb
+++ b/generated/google/apis/dialogflow_v2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/digitalassetlinks_v1.rb
+++ b/generated/google/apis/digitalassetlinks_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/digitalassetlinks_v1/classes.rb
+++ b/generated/google/apis/digitalassetlinks_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/digitalassetlinks_v1/representations.rb
+++ b/generated/google/apis/digitalassetlinks_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/digitalassetlinks_v1/service.rb
+++ b/generated/google/apis/digitalassetlinks_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/discovery_v1.rb
+++ b/generated/google/apis/discovery_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/discovery_v1/classes.rb
+++ b/generated/google/apis/discovery_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/discovery_v1/representations.rb
+++ b/generated/google/apis/discovery_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/discovery_v1/service.rb
+++ b/generated/google/apis/discovery_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dlp_v2.rb
+++ b/generated/google/apis/dlp_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dlp_v2/classes.rb
+++ b/generated/google/apis/dlp_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dlp_v2/representations.rb
+++ b/generated/google/apis/dlp_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dlp_v2/service.rb
+++ b/generated/google/apis/dlp_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1.rb
+++ b/generated/google/apis/dns_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1/classes.rb
+++ b/generated/google/apis/dns_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1/representations.rb
+++ b/generated/google/apis/dns_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1/service.rb
+++ b/generated/google/apis/dns_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1beta2.rb
+++ b/generated/google/apis/dns_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1beta2/classes.rb
+++ b/generated/google/apis/dns_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1beta2/representations.rb
+++ b/generated/google/apis/dns_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v1beta2/service.rb
+++ b/generated/google/apis/dns_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v2beta1.rb
+++ b/generated/google/apis/dns_v2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v2beta1/classes.rb
+++ b/generated/google/apis/dns_v2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v2beta1/representations.rb
+++ b/generated/google/apis/dns_v2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/dns_v2beta1/service.rb
+++ b/generated/google/apis/dns_v2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclickbidmanager_v1.rb
+++ b/generated/google/apis/doubleclickbidmanager_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclickbidmanager_v1/classes.rb
+++ b/generated/google/apis/doubleclickbidmanager_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclickbidmanager_v1/representations.rb
+++ b/generated/google/apis/doubleclickbidmanager_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclickbidmanager_v1/service.rb
+++ b/generated/google/apis/doubleclickbidmanager_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclicksearch_v2.rb
+++ b/generated/google/apis/doubleclicksearch_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclicksearch_v2/classes.rb
+++ b/generated/google/apis/doubleclicksearch_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclicksearch_v2/representations.rb
+++ b/generated/google/apis/doubleclicksearch_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/doubleclicksearch_v2/service.rb
+++ b/generated/google/apis/doubleclicksearch_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v2.rb
+++ b/generated/google/apis/drive_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v2/classes.rb
+++ b/generated/google/apis/drive_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v2/representations.rb
+++ b/generated/google/apis/drive_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v2/service.rb
+++ b/generated/google/apis/drive_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v3.rb
+++ b/generated/google/apis/drive_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v3/classes.rb
+++ b/generated/google/apis/drive_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v3/representations.rb
+++ b/generated/google/apis/drive_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/drive_v3/service.rb
+++ b/generated/google/apis/drive_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/driveactivity_v2.rb
+++ b/generated/google/apis/driveactivity_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/driveactivity_v2/classes.rb
+++ b/generated/google/apis/driveactivity_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/driveactivity_v2/representations.rb
+++ b/generated/google/apis/driveactivity_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/driveactivity_v2/service.rb
+++ b/generated/google/apis/driveactivity_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1.rb
+++ b/generated/google/apis/file_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1/classes.rb
+++ b/generated/google/apis/file_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1/representations.rb
+++ b/generated/google/apis/file_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1/service.rb
+++ b/generated/google/apis/file_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1beta1.rb
+++ b/generated/google/apis/file_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1beta1/classes.rb
+++ b/generated/google/apis/file_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1beta1/representations.rb
+++ b/generated/google/apis/file_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/file_v1beta1/service.rb
+++ b/generated/google/apis/file_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasedynamiclinks_v1.rb
+++ b/generated/google/apis/firebasedynamiclinks_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasedynamiclinks_v1/classes.rb
+++ b/generated/google/apis/firebasedynamiclinks_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasedynamiclinks_v1/representations.rb
+++ b/generated/google/apis/firebasedynamiclinks_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasedynamiclinks_v1/service.rb
+++ b/generated/google/apis/firebasedynamiclinks_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasehosting_v1beta1.rb
+++ b/generated/google/apis/firebasehosting_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasehosting_v1beta1/classes.rb
+++ b/generated/google/apis/firebasehosting_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasehosting_v1beta1/representations.rb
+++ b/generated/google/apis/firebasehosting_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebasehosting_v1beta1/service.rb
+++ b/generated/google/apis/firebasehosting_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebaserules_v1.rb
+++ b/generated/google/apis/firebaserules_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebaserules_v1/classes.rb
+++ b/generated/google/apis/firebaserules_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebaserules_v1/representations.rb
+++ b/generated/google/apis/firebaserules_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firebaserules_v1/service.rb
+++ b/generated/google/apis/firebaserules_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1.rb
+++ b/generated/google/apis/firestore_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1/classes.rb
+++ b/generated/google/apis/firestore_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1/representations.rb
+++ b/generated/google/apis/firestore_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1/service.rb
+++ b/generated/google/apis/firestore_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta1.rb
+++ b/generated/google/apis/firestore_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta1/classes.rb
+++ b/generated/google/apis/firestore_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta1/representations.rb
+++ b/generated/google/apis/firestore_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta1/service.rb
+++ b/generated/google/apis/firestore_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta2.rb
+++ b/generated/google/apis/firestore_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta2/classes.rb
+++ b/generated/google/apis/firestore_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta2/representations.rb
+++ b/generated/google/apis/firestore_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/firestore_v1beta2/service.rb
+++ b/generated/google/apis/firestore_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fitness_v1.rb
+++ b/generated/google/apis/fitness_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fitness_v1/classes.rb
+++ b/generated/google/apis/fitness_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fitness_v1/representations.rb
+++ b/generated/google/apis/fitness_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fitness_v1/service.rb
+++ b/generated/google/apis/fitness_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v1.rb
+++ b/generated/google/apis/fusiontables_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v1/classes.rb
+++ b/generated/google/apis/fusiontables_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v1/representations.rb
+++ b/generated/google/apis/fusiontables_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v1/service.rb
+++ b/generated/google/apis/fusiontables_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v2.rb
+++ b/generated/google/apis/fusiontables_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v2/classes.rb
+++ b/generated/google/apis/fusiontables_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v2/representations.rb
+++ b/generated/google/apis/fusiontables_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/fusiontables_v2/service.rb
+++ b/generated/google/apis/fusiontables_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_configuration_v1configuration.rb
+++ b/generated/google/apis/games_configuration_v1configuration.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_configuration_v1configuration/classes.rb
+++ b/generated/google/apis/games_configuration_v1configuration/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_configuration_v1configuration/representations.rb
+++ b/generated/google/apis/games_configuration_v1configuration/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_configuration_v1configuration/service.rb
+++ b/generated/google/apis/games_configuration_v1configuration/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_management_v1management.rb
+++ b/generated/google/apis/games_management_v1management.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_management_v1management/classes.rb
+++ b/generated/google/apis/games_management_v1management/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_management_v1management/representations.rb
+++ b/generated/google/apis/games_management_v1management/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_management_v1management/service.rb
+++ b/generated/google/apis/games_management_v1management/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_v1.rb
+++ b/generated/google/apis/games_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_v1/classes.rb
+++ b/generated/google/apis/games_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_v1/representations.rb
+++ b/generated/google/apis/games_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/games_v1/service.rb
+++ b/generated/google/apis/games_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1.rb
+++ b/generated/google/apis/genomics_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1/classes.rb
+++ b/generated/google/apis/genomics_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1/representations.rb
+++ b/generated/google/apis/genomics_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1/service.rb
+++ b/generated/google/apis/genomics_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1alpha2.rb
+++ b/generated/google/apis/genomics_v1alpha2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1alpha2/classes.rb
+++ b/generated/google/apis/genomics_v1alpha2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1alpha2/representations.rb
+++ b/generated/google/apis/genomics_v1alpha2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v1alpha2/service.rb
+++ b/generated/google/apis/genomics_v1alpha2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v2alpha1.rb
+++ b/generated/google/apis/genomics_v2alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v2alpha1/classes.rb
+++ b/generated/google/apis/genomics_v2alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v2alpha1/representations.rb
+++ b/generated/google/apis/genomics_v2alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/genomics_v2alpha1/service.rb
+++ b/generated/google/apis/genomics_v2alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/gmail_v1.rb
+++ b/generated/google/apis/gmail_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/gmail_v1/classes.rb
+++ b/generated/google/apis/gmail_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/gmail_v1/representations.rb
+++ b/generated/google/apis/gmail_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/gmail_v1/service.rb
+++ b/generated/google/apis/gmail_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupsmigration_v1.rb
+++ b/generated/google/apis/groupsmigration_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupsmigration_v1/classes.rb
+++ b/generated/google/apis/groupsmigration_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupsmigration_v1/representations.rb
+++ b/generated/google/apis/groupsmigration_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupsmigration_v1/service.rb
+++ b/generated/google/apis/groupsmigration_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupssettings_v1.rb
+++ b/generated/google/apis/groupssettings_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupssettings_v1/classes.rb
+++ b/generated/google/apis/groupssettings_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupssettings_v1/representations.rb
+++ b/generated/google/apis/groupssettings_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/groupssettings_v1/service.rb
+++ b/generated/google/apis/groupssettings_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iam_v1.rb
+++ b/generated/google/apis/iam_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iam_v1/classes.rb
+++ b/generated/google/apis/iam_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iam_v1/representations.rb
+++ b/generated/google/apis/iam_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iam_v1/service.rb
+++ b/generated/google/apis/iam_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iamcredentials_v1.rb
+++ b/generated/google/apis/iamcredentials_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iamcredentials_v1/classes.rb
+++ b/generated/google/apis/iamcredentials_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iamcredentials_v1/representations.rb
+++ b/generated/google/apis/iamcredentials_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iamcredentials_v1/service.rb
+++ b/generated/google/apis/iamcredentials_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1.rb
+++ b/generated/google/apis/iap_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1/classes.rb
+++ b/generated/google/apis/iap_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1/representations.rb
+++ b/generated/google/apis/iap_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1/service.rb
+++ b/generated/google/apis/iap_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1beta1.rb
+++ b/generated/google/apis/iap_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1beta1/classes.rb
+++ b/generated/google/apis/iap_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1beta1/representations.rb
+++ b/generated/google/apis/iap_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/iap_v1beta1/service.rb
+++ b/generated/google/apis/iap_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/identitytoolkit_v3.rb
+++ b/generated/google/apis/identitytoolkit_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/identitytoolkit_v3/classes.rb
+++ b/generated/google/apis/identitytoolkit_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/identitytoolkit_v3/representations.rb
+++ b/generated/google/apis/identitytoolkit_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/identitytoolkit_v3/service.rb
+++ b/generated/google/apis/identitytoolkit_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/indexing_v3.rb
+++ b/generated/google/apis/indexing_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/indexing_v3/classes.rb
+++ b/generated/google/apis/indexing_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/indexing_v3/representations.rb
+++ b/generated/google/apis/indexing_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/indexing_v3/service.rb
+++ b/generated/google/apis/indexing_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v2.rb
+++ b/generated/google/apis/jobs_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v2/classes.rb
+++ b/generated/google/apis/jobs_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v2/representations.rb
+++ b/generated/google/apis/jobs_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v2/service.rb
+++ b/generated/google/apis/jobs_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3.rb
+++ b/generated/google/apis/jobs_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3/classes.rb
+++ b/generated/google/apis/jobs_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3/representations.rb
+++ b/generated/google/apis/jobs_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3/service.rb
+++ b/generated/google/apis/jobs_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3p1beta1.rb
+++ b/generated/google/apis/jobs_v3p1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3p1beta1/classes.rb
+++ b/generated/google/apis/jobs_v3p1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3p1beta1/representations.rb
+++ b/generated/google/apis/jobs_v3p1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/jobs_v3p1beta1/service.rb
+++ b/generated/google/apis/jobs_v3p1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/kgsearch_v1.rb
+++ b/generated/google/apis/kgsearch_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/kgsearch_v1/classes.rb
+++ b/generated/google/apis/kgsearch_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/kgsearch_v1/representations.rb
+++ b/generated/google/apis/kgsearch_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/kgsearch_v1/service.rb
+++ b/generated/google/apis/kgsearch_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1.rb
+++ b/generated/google/apis/language_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1/classes.rb
+++ b/generated/google/apis/language_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1/representations.rb
+++ b/generated/google/apis/language_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1/service.rb
+++ b/generated/google/apis/language_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta1.rb
+++ b/generated/google/apis/language_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta1/classes.rb
+++ b/generated/google/apis/language_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta1/representations.rb
+++ b/generated/google/apis/language_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta1/service.rb
+++ b/generated/google/apis/language_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta2.rb
+++ b/generated/google/apis/language_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta2/classes.rb
+++ b/generated/google/apis/language_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta2/representations.rb
+++ b/generated/google/apis/language_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/language_v1beta2/service.rb
+++ b/generated/google/apis/language_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/libraryagent_v1.rb
+++ b/generated/google/apis/libraryagent_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/libraryagent_v1/classes.rb
+++ b/generated/google/apis/libraryagent_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/libraryagent_v1/representations.rb
+++ b/generated/google/apis/libraryagent_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/libraryagent_v1/service.rb
+++ b/generated/google/apis/libraryagent_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/licensing_v1.rb
+++ b/generated/google/apis/licensing_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/licensing_v1/classes.rb
+++ b/generated/google/apis/licensing_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/licensing_v1/representations.rb
+++ b/generated/google/apis/licensing_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/licensing_v1/service.rb
+++ b/generated/google/apis/licensing_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2.rb
+++ b/generated/google/apis/logging_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2/classes.rb
+++ b/generated/google/apis/logging_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2/representations.rb
+++ b/generated/google/apis/logging_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2/service.rb
+++ b/generated/google/apis/logging_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2beta1.rb
+++ b/generated/google/apis/logging_v2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2beta1/classes.rb
+++ b/generated/google/apis/logging_v2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2beta1/representations.rb
+++ b/generated/google/apis/logging_v2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/logging_v2beta1/service.rb
+++ b/generated/google/apis/logging_v2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/manufacturers_v1.rb
+++ b/generated/google/apis/manufacturers_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/manufacturers_v1/classes.rb
+++ b/generated/google/apis/manufacturers_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/manufacturers_v1/representations.rb
+++ b/generated/google/apis/manufacturers_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/manufacturers_v1/service.rb
+++ b/generated/google/apis/manufacturers_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/mirror_v1.rb
+++ b/generated/google/apis/mirror_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/mirror_v1/classes.rb
+++ b/generated/google/apis/mirror_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/mirror_v1/representations.rb
+++ b/generated/google/apis/mirror_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/mirror_v1/service.rb
+++ b/generated/google/apis/mirror_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/ml_v1.rb
+++ b/generated/google/apis/ml_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/ml_v1/classes.rb
+++ b/generated/google/apis/ml_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/ml_v1/representations.rb
+++ b/generated/google/apis/ml_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/ml_v1/service.rb
+++ b/generated/google/apis/ml_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/monitoring_v3.rb
+++ b/generated/google/apis/monitoring_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/monitoring_v3/classes.rb
+++ b/generated/google/apis/monitoring_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/monitoring_v3/representations.rb
+++ b/generated/google/apis/monitoring_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/monitoring_v3/service.rb
+++ b/generated/google/apis/monitoring_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v1.rb
+++ b/generated/google/apis/oauth2_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v1/classes.rb
+++ b/generated/google/apis/oauth2_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v1/representations.rb
+++ b/generated/google/apis/oauth2_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v1/service.rb
+++ b/generated/google/apis/oauth2_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v2.rb
+++ b/generated/google/apis/oauth2_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v2/classes.rb
+++ b/generated/google/apis/oauth2_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v2/representations.rb
+++ b/generated/google/apis/oauth2_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oauth2_v2/service.rb
+++ b/generated/google/apis/oauth2_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1.rb
+++ b/generated/google/apis/oslogin_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1/classes.rb
+++ b/generated/google/apis/oslogin_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1/representations.rb
+++ b/generated/google/apis/oslogin_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1/service.rb
+++ b/generated/google/apis/oslogin_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1alpha.rb
+++ b/generated/google/apis/oslogin_v1alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1alpha/classes.rb
+++ b/generated/google/apis/oslogin_v1alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1alpha/representations.rb
+++ b/generated/google/apis/oslogin_v1alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1alpha/service.rb
+++ b/generated/google/apis/oslogin_v1alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1beta.rb
+++ b/generated/google/apis/oslogin_v1beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1beta/classes.rb
+++ b/generated/google/apis/oslogin_v1beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1beta/representations.rb
+++ b/generated/google/apis/oslogin_v1beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/oslogin_v1beta/service.rb
+++ b/generated/google/apis/oslogin_v1beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v1.rb
+++ b/generated/google/apis/pagespeedonline_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v1/classes.rb
+++ b/generated/google/apis/pagespeedonline_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v1/representations.rb
+++ b/generated/google/apis/pagespeedonline_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v1/service.rb
+++ b/generated/google/apis/pagespeedonline_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v2.rb
+++ b/generated/google/apis/pagespeedonline_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v2/classes.rb
+++ b/generated/google/apis/pagespeedonline_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v2/representations.rb
+++ b/generated/google/apis/pagespeedonline_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v2/service.rb
+++ b/generated/google/apis/pagespeedonline_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v4.rb
+++ b/generated/google/apis/pagespeedonline_v4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v4/classes.rb
+++ b/generated/google/apis/pagespeedonline_v4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v4/representations.rb
+++ b/generated/google/apis/pagespeedonline_v4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v4/service.rb
+++ b/generated/google/apis/pagespeedonline_v4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v5.rb
+++ b/generated/google/apis/pagespeedonline_v5.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v5/classes.rb
+++ b/generated/google/apis/pagespeedonline_v5/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v5/representations.rb
+++ b/generated/google/apis/pagespeedonline_v5/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pagespeedonline_v5/service.rb
+++ b/generated/google/apis/pagespeedonline_v5/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/partners_v2.rb
+++ b/generated/google/apis/partners_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/partners_v2/classes.rb
+++ b/generated/google/apis/partners_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/partners_v2/representations.rb
+++ b/generated/google/apis/partners_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/partners_v2/service.rb
+++ b/generated/google/apis/partners_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/people_v1.rb
+++ b/generated/google/apis/people_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/people_v1/classes.rb
+++ b/generated/google/apis/people_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/people_v1/representations.rb
+++ b/generated/google/apis/people_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/people_v1/service.rb
+++ b/generated/google/apis/people_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/playcustomapp_v1.rb
+++ b/generated/google/apis/playcustomapp_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/playcustomapp_v1/classes.rb
+++ b/generated/google/apis/playcustomapp_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/playcustomapp_v1/representations.rb
+++ b/generated/google/apis/playcustomapp_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/playcustomapp_v1/service.rb
+++ b/generated/google/apis/playcustomapp_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_domains_v1.rb
+++ b/generated/google/apis/plus_domains_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_domains_v1/classes.rb
+++ b/generated/google/apis/plus_domains_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_domains_v1/representations.rb
+++ b/generated/google/apis/plus_domains_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_domains_v1/service.rb
+++ b/generated/google/apis/plus_domains_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_v1.rb
+++ b/generated/google/apis/plus_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_v1/classes.rb
+++ b/generated/google/apis/plus_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_v1/representations.rb
+++ b/generated/google/apis/plus_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/plus_v1/service.rb
+++ b/generated/google/apis/plus_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/poly_v1.rb
+++ b/generated/google/apis/poly_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/poly_v1/classes.rb
+++ b/generated/google/apis/poly_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/poly_v1/representations.rb
+++ b/generated/google/apis/poly_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/poly_v1/service.rb
+++ b/generated/google/apis/poly_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/proximitybeacon_v1beta1.rb
+++ b/generated/google/apis/proximitybeacon_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/proximitybeacon_v1beta1/classes.rb
+++ b/generated/google/apis/proximitybeacon_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/proximitybeacon_v1beta1/representations.rb
+++ b/generated/google/apis/proximitybeacon_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/proximitybeacon_v1beta1/service.rb
+++ b/generated/google/apis/proximitybeacon_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1.rb
+++ b/generated/google/apis/pubsub_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1/classes.rb
+++ b/generated/google/apis/pubsub_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1/representations.rb
+++ b/generated/google/apis/pubsub_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1/service.rb
+++ b/generated/google/apis/pubsub_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta1a.rb
+++ b/generated/google/apis/pubsub_v1beta1a.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta1a/classes.rb
+++ b/generated/google/apis/pubsub_v1beta1a/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta1a/representations.rb
+++ b/generated/google/apis/pubsub_v1beta1a/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta1a/service.rb
+++ b/generated/google/apis/pubsub_v1beta1a/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta2.rb
+++ b/generated/google/apis/pubsub_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta2/classes.rb
+++ b/generated/google/apis/pubsub_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta2/representations.rb
+++ b/generated/google/apis/pubsub_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/pubsub_v1beta2/service.rb
+++ b/generated/google/apis/pubsub_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1.rb
+++ b/generated/google/apis/redis_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1/classes.rb
+++ b/generated/google/apis/redis_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1/representations.rb
+++ b/generated/google/apis/redis_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1/service.rb
+++ b/generated/google/apis/redis_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1beta1.rb
+++ b/generated/google/apis/redis_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1beta1/classes.rb
+++ b/generated/google/apis/redis_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1beta1/representations.rb
+++ b/generated/google/apis/redis_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/redis_v1beta1/service.rb
+++ b/generated/google/apis/redis_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1.rb
+++ b/generated/google/apis/remotebuildexecution_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1/classes.rb
+++ b/generated/google/apis/remotebuildexecution_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1/representations.rb
+++ b/generated/google/apis/remotebuildexecution_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1/service.rb
+++ b/generated/google/apis/remotebuildexecution_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1alpha.rb
+++ b/generated/google/apis/remotebuildexecution_v1alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1alpha/classes.rb
+++ b/generated/google/apis/remotebuildexecution_v1alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1alpha/representations.rb
+++ b/generated/google/apis/remotebuildexecution_v1alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v1alpha/service.rb
+++ b/generated/google/apis/remotebuildexecution_v1alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v2.rb
+++ b/generated/google/apis/remotebuildexecution_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v2/classes.rb
+++ b/generated/google/apis/remotebuildexecution_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v2/representations.rb
+++ b/generated/google/apis/remotebuildexecution_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/remotebuildexecution_v2/service.rb
+++ b/generated/google/apis/remotebuildexecution_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/replicapool_v1beta1.rb
+++ b/generated/google/apis/replicapool_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/replicapool_v1beta1/classes.rb
+++ b/generated/google/apis/replicapool_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/replicapool_v1beta1/representations.rb
+++ b/generated/google/apis/replicapool_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/replicapool_v1beta1/service.rb
+++ b/generated/google/apis/replicapool_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/reseller_v1.rb
+++ b/generated/google/apis/reseller_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/reseller_v1/classes.rb
+++ b/generated/google/apis/reseller_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/reseller_v1/representations.rb
+++ b/generated/google/apis/reseller_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/reseller_v1/service.rb
+++ b/generated/google/apis/reseller_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1.rb
+++ b/generated/google/apis/runtimeconfig_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1/classes.rb
+++ b/generated/google/apis/runtimeconfig_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1/representations.rb
+++ b/generated/google/apis/runtimeconfig_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1/service.rb
+++ b/generated/google/apis/runtimeconfig_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1beta1.rb
+++ b/generated/google/apis/runtimeconfig_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1beta1/classes.rb
+++ b/generated/google/apis/runtimeconfig_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1beta1/representations.rb
+++ b/generated/google/apis/runtimeconfig_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/runtimeconfig_v1beta1/service.rb
+++ b/generated/google/apis/runtimeconfig_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/safebrowsing_v4.rb
+++ b/generated/google/apis/safebrowsing_v4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/safebrowsing_v4/classes.rb
+++ b/generated/google/apis/safebrowsing_v4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/safebrowsing_v4/representations.rb
+++ b/generated/google/apis/safebrowsing_v4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/safebrowsing_v4/service.rb
+++ b/generated/google/apis/safebrowsing_v4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/script_v1.rb
+++ b/generated/google/apis/script_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/script_v1/classes.rb
+++ b/generated/google/apis/script_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/script_v1/representations.rb
+++ b/generated/google/apis/script_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/script_v1/service.rb
+++ b/generated/google/apis/script_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/searchconsole_v1.rb
+++ b/generated/google/apis/searchconsole_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/searchconsole_v1/classes.rb
+++ b/generated/google/apis/searchconsole_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/searchconsole_v1/representations.rb
+++ b/generated/google/apis/searchconsole_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/searchconsole_v1/service.rb
+++ b/generated/google/apis/searchconsole_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1.rb
+++ b/generated/google/apis/servicebroker_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1/classes.rb
+++ b/generated/google/apis/servicebroker_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1/representations.rb
+++ b/generated/google/apis/servicebroker_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1/service.rb
+++ b/generated/google/apis/servicebroker_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1alpha1.rb
+++ b/generated/google/apis/servicebroker_v1alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1alpha1/classes.rb
+++ b/generated/google/apis/servicebroker_v1alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1alpha1/representations.rb
+++ b/generated/google/apis/servicebroker_v1alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1alpha1/service.rb
+++ b/generated/google/apis/servicebroker_v1alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1beta1.rb
+++ b/generated/google/apis/servicebroker_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1beta1/classes.rb
+++ b/generated/google/apis/servicebroker_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1beta1/representations.rb
+++ b/generated/google/apis/servicebroker_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicebroker_v1beta1/service.rb
+++ b/generated/google/apis/servicebroker_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceconsumermanagement_v1.rb
+++ b/generated/google/apis/serviceconsumermanagement_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceconsumermanagement_v1/classes.rb
+++ b/generated/google/apis/serviceconsumermanagement_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceconsumermanagement_v1/representations.rb
+++ b/generated/google/apis/serviceconsumermanagement_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceconsumermanagement_v1/service.rb
+++ b/generated/google/apis/serviceconsumermanagement_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicecontrol_v1.rb
+++ b/generated/google/apis/servicecontrol_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicecontrol_v1/classes.rb
+++ b/generated/google/apis/servicecontrol_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicecontrol_v1/representations.rb
+++ b/generated/google/apis/servicecontrol_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicecontrol_v1/service.rb
+++ b/generated/google/apis/servicecontrol_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicemanagement_v1.rb
+++ b/generated/google/apis/servicemanagement_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicemanagement_v1/classes.rb
+++ b/generated/google/apis/servicemanagement_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicemanagement_v1/representations.rb
+++ b/generated/google/apis/servicemanagement_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicemanagement_v1/service.rb
+++ b/generated/google/apis/servicemanagement_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicenetworking_v1beta.rb
+++ b/generated/google/apis/servicenetworking_v1beta.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicenetworking_v1beta/classes.rb
+++ b/generated/google/apis/servicenetworking_v1beta/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicenetworking_v1beta/representations.rb
+++ b/generated/google/apis/servicenetworking_v1beta/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/servicenetworking_v1beta/service.rb
+++ b/generated/google/apis/servicenetworking_v1beta/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1.rb
+++ b/generated/google/apis/serviceusage_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1/classes.rb
+++ b/generated/google/apis/serviceusage_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1/representations.rb
+++ b/generated/google/apis/serviceusage_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1/service.rb
+++ b/generated/google/apis/serviceusage_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1beta1.rb
+++ b/generated/google/apis/serviceusage_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1beta1/classes.rb
+++ b/generated/google/apis/serviceusage_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1beta1/representations.rb
+++ b/generated/google/apis/serviceusage_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/serviceusage_v1beta1/service.rb
+++ b/generated/google/apis/serviceusage_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sheets_v4.rb
+++ b/generated/google/apis/sheets_v4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sheets_v4/classes.rb
+++ b/generated/google/apis/sheets_v4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sheets_v4/representations.rb
+++ b/generated/google/apis/sheets_v4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sheets_v4/service.rb
+++ b/generated/google/apis/sheets_v4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/site_verification_v1.rb
+++ b/generated/google/apis/site_verification_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/site_verification_v1/classes.rb
+++ b/generated/google/apis/site_verification_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/site_verification_v1/representations.rb
+++ b/generated/google/apis/site_verification_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/site_verification_v1/service.rb
+++ b/generated/google/apis/site_verification_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/slides_v1.rb
+++ b/generated/google/apis/slides_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/slides_v1/classes.rb
+++ b/generated/google/apis/slides_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/slides_v1/representations.rb
+++ b/generated/google/apis/slides_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/slides_v1/service.rb
+++ b/generated/google/apis/slides_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sourcerepo_v1.rb
+++ b/generated/google/apis/sourcerepo_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sourcerepo_v1/classes.rb
+++ b/generated/google/apis/sourcerepo_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sourcerepo_v1/representations.rb
+++ b/generated/google/apis/sourcerepo_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sourcerepo_v1/service.rb
+++ b/generated/google/apis/sourcerepo_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/spanner_v1.rb
+++ b/generated/google/apis/spanner_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/spanner_v1/classes.rb
+++ b/generated/google/apis/spanner_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/spanner_v1/representations.rb
+++ b/generated/google/apis/spanner_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/spanner_v1/service.rb
+++ b/generated/google/apis/spanner_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1.rb
+++ b/generated/google/apis/speech_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1/classes.rb
+++ b/generated/google/apis/speech_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1/representations.rb
+++ b/generated/google/apis/speech_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1/service.rb
+++ b/generated/google/apis/speech_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1p1beta1.rb
+++ b/generated/google/apis/speech_v1p1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1p1beta1/classes.rb
+++ b/generated/google/apis/speech_v1p1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1p1beta1/representations.rb
+++ b/generated/google/apis/speech_v1p1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/speech_v1p1beta1/service.rb
+++ b/generated/google/apis/speech_v1p1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sqladmin_v1beta4.rb
+++ b/generated/google/apis/sqladmin_v1beta4.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sqladmin_v1beta4/classes.rb
+++ b/generated/google/apis/sqladmin_v1beta4/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sqladmin_v1beta4/representations.rb
+++ b/generated/google/apis/sqladmin_v1beta4/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/sqladmin_v1beta4/service.rb
+++ b/generated/google/apis/sqladmin_v1beta4/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1.rb
+++ b/generated/google/apis/storage_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1/classes.rb
+++ b/generated/google/apis/storage_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1/representations.rb
+++ b/generated/google/apis/storage_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1/service.rb
+++ b/generated/google/apis/storage_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta1.rb
+++ b/generated/google/apis/storage_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta1/classes.rb
+++ b/generated/google/apis/storage_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta1/representations.rb
+++ b/generated/google/apis/storage_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta1/service.rb
+++ b/generated/google/apis/storage_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta2.rb
+++ b/generated/google/apis/storage_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta2/classes.rb
+++ b/generated/google/apis/storage_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta2/representations.rb
+++ b/generated/google/apis/storage_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storage_v1beta2/service.rb
+++ b/generated/google/apis/storage_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storagetransfer_v1.rb
+++ b/generated/google/apis/storagetransfer_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storagetransfer_v1/classes.rb
+++ b/generated/google/apis/storagetransfer_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storagetransfer_v1/representations.rb
+++ b/generated/google/apis/storagetransfer_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/storagetransfer_v1/service.rb
+++ b/generated/google/apis/storagetransfer_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/streetviewpublish_v1.rb
+++ b/generated/google/apis/streetviewpublish_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/streetviewpublish_v1/classes.rb
+++ b/generated/google/apis/streetviewpublish_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/streetviewpublish_v1/representations.rb
+++ b/generated/google/apis/streetviewpublish_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/streetviewpublish_v1/service.rb
+++ b/generated/google/apis/streetviewpublish_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/surveys_v2.rb
+++ b/generated/google/apis/surveys_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/surveys_v2/classes.rb
+++ b/generated/google/apis/surveys_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/surveys_v2/representations.rb
+++ b/generated/google/apis/surveys_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/surveys_v2/service.rb
+++ b/generated/google/apis/surveys_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v1.rb
+++ b/generated/google/apis/tagmanager_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v1/classes.rb
+++ b/generated/google/apis/tagmanager_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v1/representations.rb
+++ b/generated/google/apis/tagmanager_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v1/service.rb
+++ b/generated/google/apis/tagmanager_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v2.rb
+++ b/generated/google/apis/tagmanager_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v2/classes.rb
+++ b/generated/google/apis/tagmanager_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v2/representations.rb
+++ b/generated/google/apis/tagmanager_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tagmanager_v2/service.rb
+++ b/generated/google/apis/tagmanager_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tasks_v1.rb
+++ b/generated/google/apis/tasks_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tasks_v1/classes.rb
+++ b/generated/google/apis/tasks_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tasks_v1/representations.rb
+++ b/generated/google/apis/tasks_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tasks_v1/service.rb
+++ b/generated/google/apis/tasks_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/testing_v1.rb
+++ b/generated/google/apis/testing_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/testing_v1/classes.rb
+++ b/generated/google/apis/testing_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/testing_v1/representations.rb
+++ b/generated/google/apis/testing_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/testing_v1/service.rb
+++ b/generated/google/apis/testing_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1.rb
+++ b/generated/google/apis/texttospeech_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1/classes.rb
+++ b/generated/google/apis/texttospeech_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1/representations.rb
+++ b/generated/google/apis/texttospeech_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1/service.rb
+++ b/generated/google/apis/texttospeech_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1beta1.rb
+++ b/generated/google/apis/texttospeech_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1beta1/classes.rb
+++ b/generated/google/apis/texttospeech_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1beta1/representations.rb
+++ b/generated/google/apis/texttospeech_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/texttospeech_v1beta1/service.rb
+++ b/generated/google/apis/texttospeech_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/toolresults_v1beta3.rb
+++ b/generated/google/apis/toolresults_v1beta3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/toolresults_v1beta3/classes.rb
+++ b/generated/google/apis/toolresults_v1beta3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/toolresults_v1beta3/representations.rb
+++ b/generated/google/apis/toolresults_v1beta3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/toolresults_v1beta3/service.rb
+++ b/generated/google/apis/toolresults_v1beta3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1.rb
+++ b/generated/google/apis/tpu_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1/classes.rb
+++ b/generated/google/apis/tpu_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1/representations.rb
+++ b/generated/google/apis/tpu_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1/service.rb
+++ b/generated/google/apis/tpu_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1alpha1.rb
+++ b/generated/google/apis/tpu_v1alpha1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1alpha1/classes.rb
+++ b/generated/google/apis/tpu_v1alpha1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1alpha1/representations.rb
+++ b/generated/google/apis/tpu_v1alpha1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/tpu_v1alpha1/service.rb
+++ b/generated/google/apis/tpu_v1alpha1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/translate_v2.rb
+++ b/generated/google/apis/translate_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/translate_v2/classes.rb
+++ b/generated/google/apis/translate_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/translate_v2/representations.rb
+++ b/generated/google/apis/translate_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/translate_v2/service.rb
+++ b/generated/google/apis/translate_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/urlshortener_v1.rb
+++ b/generated/google/apis/urlshortener_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/urlshortener_v1/classes.rb
+++ b/generated/google/apis/urlshortener_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/urlshortener_v1/representations.rb
+++ b/generated/google/apis/urlshortener_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/urlshortener_v1/service.rb
+++ b/generated/google/apis/urlshortener_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vault_v1.rb
+++ b/generated/google/apis/vault_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vault_v1/classes.rb
+++ b/generated/google/apis/vault_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vault_v1/representations.rb
+++ b/generated/google/apis/vault_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vault_v1/service.rb
+++ b/generated/google/apis/vault_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1.rb
+++ b/generated/google/apis/videointelligence_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1/classes.rb
+++ b/generated/google/apis/videointelligence_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1/representations.rb
+++ b/generated/google/apis/videointelligence_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1/service.rb
+++ b/generated/google/apis/videointelligence_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1beta2.rb
+++ b/generated/google/apis/videointelligence_v1beta2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1beta2/classes.rb
+++ b/generated/google/apis/videointelligence_v1beta2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1beta2/representations.rb
+++ b/generated/google/apis/videointelligence_v1beta2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1beta2/service.rb
+++ b/generated/google/apis/videointelligence_v1beta2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1p1beta1.rb
+++ b/generated/google/apis/videointelligence_v1p1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1p1beta1/classes.rb
+++ b/generated/google/apis/videointelligence_v1p1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1p1beta1/representations.rb
+++ b/generated/google/apis/videointelligence_v1p1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/videointelligence_v1p1beta1/service.rb
+++ b/generated/google/apis/videointelligence_v1p1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1.rb
+++ b/generated/google/apis/vision_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1/classes.rb
+++ b/generated/google/apis/vision_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1/representations.rb
+++ b/generated/google/apis/vision_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1/service.rb
+++ b/generated/google/apis/vision_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p1beta1.rb
+++ b/generated/google/apis/vision_v1p1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p1beta1/classes.rb
+++ b/generated/google/apis/vision_v1p1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p1beta1/representations.rb
+++ b/generated/google/apis/vision_v1p1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p1beta1/service.rb
+++ b/generated/google/apis/vision_v1p1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p2beta1.rb
+++ b/generated/google/apis/vision_v1p2beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p2beta1/classes.rb
+++ b/generated/google/apis/vision_v1p2beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p2beta1/representations.rb
+++ b/generated/google/apis/vision_v1p2beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/vision_v1p2beta1/service.rb
+++ b/generated/google/apis/vision_v1p2beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webfonts_v1.rb
+++ b/generated/google/apis/webfonts_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webfonts_v1/classes.rb
+++ b/generated/google/apis/webfonts_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webfonts_v1/representations.rb
+++ b/generated/google/apis/webfonts_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webfonts_v1/service.rb
+++ b/generated/google/apis/webfonts_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webmasters_v3.rb
+++ b/generated/google/apis/webmasters_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webmasters_v3/classes.rb
+++ b/generated/google/apis/webmasters_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webmasters_v3/representations.rb
+++ b/generated/google/apis/webmasters_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/webmasters_v3/service.rb
+++ b/generated/google/apis/webmasters_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/websecurityscanner_v1alpha.rb
+++ b/generated/google/apis/websecurityscanner_v1alpha.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/websecurityscanner_v1alpha/classes.rb
+++ b/generated/google/apis/websecurityscanner_v1alpha/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/websecurityscanner_v1alpha/representations.rb
+++ b/generated/google/apis/websecurityscanner_v1alpha/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/websecurityscanner_v1alpha/service.rb
+++ b/generated/google/apis/websecurityscanner_v1alpha/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1.rb
+++ b/generated/google/apis/youtube_analytics_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1/classes.rb
+++ b/generated/google/apis/youtube_analytics_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1/representations.rb
+++ b/generated/google/apis/youtube_analytics_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1/service.rb
+++ b/generated/google/apis/youtube_analytics_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1beta1.rb
+++ b/generated/google/apis/youtube_analytics_v1beta1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1beta1/classes.rb
+++ b/generated/google/apis/youtube_analytics_v1beta1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1beta1/representations.rb
+++ b/generated/google/apis/youtube_analytics_v1beta1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v1beta1/service.rb
+++ b/generated/google/apis/youtube_analytics_v1beta1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v2.rb
+++ b/generated/google/apis/youtube_analytics_v2.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v2/classes.rb
+++ b/generated/google/apis/youtube_analytics_v2/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v2/representations.rb
+++ b/generated/google/apis/youtube_analytics_v2/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_analytics_v2/service.rb
+++ b/generated/google/apis/youtube_analytics_v2/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_partner_v1.rb
+++ b/generated/google/apis/youtube_partner_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_partner_v1/classes.rb
+++ b/generated/google/apis/youtube_partner_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_partner_v1/representations.rb
+++ b/generated/google/apis/youtube_partner_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_partner_v1/service.rb
+++ b/generated/google/apis/youtube_partner_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_v3.rb
+++ b/generated/google/apis/youtube_v3.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_v3/classes.rb
+++ b/generated/google/apis/youtube_v3/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_v3/representations.rb
+++ b/generated/google/apis/youtube_v3/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtube_v3/service.rb
+++ b/generated/google/apis/youtube_v3/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtubereporting_v1.rb
+++ b/generated/google/apis/youtubereporting_v1.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtubereporting_v1/classes.rb
+++ b/generated/google/apis/youtubereporting_v1/classes.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtubereporting_v1/representations.rb
+++ b/generated/google/apis/youtubereporting_v1/representations.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/generated/google/apis/youtubereporting_v1/service.rb
+++ b/generated/google/apis/youtubereporting_v1/service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/auth/installed_app.rb
+++ b/lib/google/api_client/auth/installed_app.rb
@@ -1,4 +1,4 @@
-# Copyright 2010 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/auth/key_utils.rb
+++ b/lib/google/api_client/auth/key_utils.rb
@@ -1,4 +1,4 @@
-# Copyright 2010 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/auth/storage.rb
+++ b/lib/google/api_client/auth/storage.rb
@@ -1,4 +1,4 @@
-# Copyright 2013 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/auth/storages/file_store.rb
+++ b/lib/google/api_client/auth/storages/file_store.rb
@@ -1,4 +1,4 @@
-# Copyright 2013 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/auth/storages/redis_store.rb
+++ b/lib/google/api_client/auth/storages/redis_store.rb
@@ -1,4 +1,4 @@
-# Copyright 2013 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/api_client/client_secrets.rb
+++ b/lib/google/api_client/client_secrets.rb
@@ -1,4 +1,4 @@
-# Copyright 2010 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis.rb
+++ b/lib/google/apis.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/base_service.rb
+++ b/lib/google/apis/core/base_service.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/batch.rb
+++ b/lib/google/apis/core/batch.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/composite_io.rb
+++ b/lib/google/apis/core/composite_io.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/download.rb
+++ b/lib/google/apis/core/download.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/hashable.rb
+++ b/lib/google/apis/core/hashable.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/json_representation.rb
+++ b/lib/google/apis/core/json_representation.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/logging.rb
+++ b/lib/google/apis/core/logging.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/multipart.rb
+++ b/lib/google/apis/core/multipart.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/errors.rb
+++ b/lib/google/apis/errors.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator.rb
+++ b/lib/google/apis/generator.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/annotator.rb
+++ b/lib/google/apis/generator/annotator.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/model.rb
+++ b/lib/google/apis/generator/model.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/template.rb
+++ b/lib/google/apis/generator/template.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/templates/classes.rb.tmpl
+++ b/lib/google/apis/generator/templates/classes.rb.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/templates/module.rb.tmpl
+++ b/lib/google/apis/generator/templates/module.rb.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/templates/representations.rb.tmpl
+++ b/lib/google/apis/generator/templates/representations.rb.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/generator/templates/service.rb.tmpl
+++ b/lib/google/apis/generator/templates/service.rb.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/options.rb
+++ b/lib/google/apis/options.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/base_cli.rb
+++ b/samples/cli/lib/base_cli.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/adsense.rb
+++ b/samples/cli/lib/samples/adsense.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/analytics.rb
+++ b/samples/cli/lib/samples/analytics.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/androidpublisher.rb
+++ b/samples/cli/lib/samples/androidpublisher.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/bigquery.rb
+++ b/samples/cli/lib/samples/bigquery.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/calendar.rb
+++ b/samples/cli/lib/samples/calendar.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/drive.rb
+++ b/samples/cli/lib/samples/drive.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/gmail.rb
+++ b/samples/cli/lib/samples/gmail.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/pubsub.rb
+++ b/samples/cli/lib/samples/pubsub.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/sheets.rb
+++ b/samples/cli/lib/samples/sheets.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/translate.rb
+++ b/samples/cli/lib/samples/translate.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/vision.rb
+++ b/samples/cli/lib/samples/vision.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/cli/lib/samples/you_tube.rb
+++ b/samples/cli/lib/samples/you_tube.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/web/app.rb
+++ b/samples/web/app.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/web/views/calendar.erb
+++ b/samples/web/views/calendar.erb
@@ -1,5 +1,5 @@
 <%#
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/web/views/drive.erb
+++ b/samples/web/views/drive.erb
@@ -1,5 +1,5 @@
 <%#
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/web/views/home.erb
+++ b/samples/web/views/home.erb
@@ -1,5 +1,5 @@
 <%#
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/web/views/layout.erb
+++ b/samples/web/views/layout.erb
@@ -1,5 +1,5 @@
 <%#
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/api_client/client_secrets_spec.rb
+++ b/spec/google/api_client/client_secrets_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2013 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/api_command_spec.rb
+++ b/spec/google/apis/core/api_command_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/batch_spec.rb
+++ b/spec/google/apis/core/batch_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/composite_io_spec.rb
+++ b/spec/google/apis/core/composite_io_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/download_spec.rb
+++ b/spec/google/apis/core/download_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/hashable_spec.rb
+++ b/spec/google/apis/core/hashable_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/http_command_spec.rb
+++ b/spec/google/apis/core/http_command_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/json_representation_spec.rb
+++ b/spec/google/apis/core/json_representation_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/core/upload_spec.rb
+++ b/spec/google/apis/core/upload_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/errors_spec.rb
+++ b/spec/google/apis/errors_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/generated_spec.rb
+++ b/spec/google/apis/generated_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/generator/generator_spec.rb
+++ b/spec/google/apis/generator/generator_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/logging_spec.rb
+++ b/spec/google/apis/logging_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/options_spec.rb
+++ b/spec/google/apis/options_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/google/apis/versions_spec.rb
+++ b/spec/google/apis/versions_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/integration_tests/url_shortener_spec.rb
+++ b/spec/integration_tests/url_shortener_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/spec_helper/load_path_spec.rb
+++ b/spec/spec_helper/load_path_spec.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Add 2.6.0 to list of ruby versions to run tests on
* Update all copyrights to 2019