### PR TITLE
Strip CR for OS_VERSION used in User-Agent header

### DIFF
--- a/lib/google/api_client/environment.rb
+++ b/lib/google/api_client/environment.rb
@@ -36,7 +36,7 @@ module Google
         end
       rescue Exception
         RUBY_PLATFORM
-      end
+      end.strip
     end
   end
 end


### PR DESCRIPTION
When the OS is Mac OS X, the command `sw_vers -productVersion` returns a version including a CR (`\n`) e.g.:  "Mac OS X/10.13.4\n", when this is later passed to the `user_agent` (https://github.com/zucaritask/google-api-ruby-client/blob/5c3bedd4163dbbd3fb776a13f0bdbf6b2c669663/lib/google/api_client.rb#L114) method to be used when making the requests, this fails as no `CR` characters are allowed in Headers.

This commit strips down the OS_VERSION in case any other of those return values include a CR and fixes such problem.
