### PR TITLE
Fix exception when API desc doesn't include parameters

### DIFF
--- a/lib/google/apis/generator/model.rb
+++ b/lib/google/apis/generator/model.rb
@@ -163,7 +163,7 @@ module Google
         end
 
         def parameters
-          Hash[(@parameters || {}).sort].reject! { |k, _v| PARAMETER_BLACKLIST.include?(k) }
+          Hash[(@parameters || {}).sort].delete_if { |k, _v| PARAMETER_BLACKLIST.include?(k) }
         end
 
         def schemas

--- a/spec/google/apis/generator/generator_spec.rb
+++ b/spec/google/apis/generator/generator_spec.rb
@@ -326,4 +326,22 @@ EOF
       end
     end
   end
+
+  context 'with minimal API description' do
+    before do
+      generated_files = Google::Apis::Generator.new.render(
+        '{ "name": "minimal_api", "id": "minimal_api", "version": "v1" }'
+      )
+
+      namespace.send(:binding).eval(
+        generated_files.fetch('google/apis/minimal_api_v1/service.rb')
+      )
+    end
+
+    let(:namespace) { Module.new }
+
+    it 'should define service class' do
+      expect(namespace).to be_const_defined('Google::Apis::MinimalApiV1::MinimalApiService')
+    end
+  end
 end


### PR DESCRIPTION
`Hash#reject!` is equivalent to `Hash#delete_if`, but returns nil if no changes were made.

Resolves #767 