### PR TITLE
Strip CR for OS_VERSION used in User-Agent header for MacOS X

### DIFF
--- a/lib/google/api_client/environment.rb
+++ b/lib/google/api_client/environment.rb
@@ -32,7 +32,7 @@ module Google
           version = java.lang.System.getProperty('os.version')
           "#{name}/#{version}"
         else
-          `uname -sr`.sub(' ', '/')
+          `uname -sr`.sub(' ', '/').strip
         end
       rescue Exception
         RUBY_PLATFORM

--- a/lib/google/api_client/environment.rb
+++ b/lib/google/api_client/environment.rb
@@ -23,7 +23,7 @@ module Google
           # to the `ver` command.
           `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '').strip
         elsif RUBY_PLATFORM =~ /darwin/i
-          "Mac OS X/#{`sw_vers -productVersion`}"
+          "Mac OS X/#{`sw_vers -productVersion`}".strip
         elsif RUBY_PLATFORM == 'java'
           # Get the information from java system properties to avoid spawning a
           # sub-process, which is not friendly in some contexts (web servers).

--- a/spec/google/api_client/environment_spec.rb
+++ b/spec/google/api_client/environment_spec.rb
@@ -1,0 +1,40 @@
+# encoding:utf-8
+
+# Copyright 2013 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+RSpec.describe Google::APIClient::ENV do
+
+  context 'on MacOS (Darwin)' do
+    before do
+      Object.send(:remove_const, 'RUBY_PLATFORM')
+      Object.const_set('RUBY_PLATFORM', 'x86_64-darwin14')
+      allow_any_instance_of(Module).to receive(:`).and_return("10.13.5\n")
+      if Object.const_defined?('Google::APIClient::ENV::OS_VERSION')
+         Google::APIClient::ENV.send(:remove_const, 'OS_VERSION')
+      end
+    end
+
+    subject(:environment) { Google::APIClient::ENV }
+
+    it 'should return an OS_VERSION without carriage return char' do
+      # Reloading in case previous tests have already loaded OS_VERSION
+      load 'google/api_client/environment.rb'
+      expect(environment::OS_VERSION).to be == 'Mac OS X/10.13.5'
+    end
+  end
+end
+


### PR DESCRIPTION
When the OS is Mac OS X, the command `sw_vers -productVersion` returns a version including a CR (`\n`) e.g.: "Mac OS X/10.13.4\n", when this is later passed to the `user_agent` (https://github.com/zucaritask/google-api-ruby-client/blob/5c3bedd4163dbbd3fb776a13f0bdbf6b2c669663/lib/google/api_client.rb#L114) method to be used when making the requests, this fails as no `CR` characters are allowed in Headers.

This commit strips down the OS_VERSION for Darwin based OSes and fixes such problem.
The spec for such scenario is also included with a note on why the loading of the subject file in the test is only load in the `it` block of the rspec test.