### PR TITLE
Remove third_party directory from gemspec

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
                        .reject { |f| f.match(%r{^(spec|script)/|^api_names_out}) }
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.require_paths = %w[lib generated third_party]
+  spec.require_paths = %w[lib generated]
 
   spec.required_ruby_version = '~> 2.0'
 

--- a/spec/spec_helper/load_path_spec.rb
+++ b/spec/spec_helper/load_path_spec.rb
@@ -26,8 +26,4 @@ RSpec.describe $LOAD_PATH do
   it('should contain GENERATED_DIR') do
     expect($LOAD_PATH).to include(GENERATED_DIR)
   end
-
-  it('should contain THIRD_PARTY_DIR') do
-    expect($LOAD_PATH).to include(THIRD_PARTY_DIR)
-  end
 end


### PR DESCRIPTION
This directory was used when the gem was patching other gems,
like Hurley. But now this directory has been removed.