### PR TITLE
Fix generate-api names_out usage

### DIFF
--- a/bin/generate-api
+++ b/bin/generate-api
@@ -37,7 +37,9 @@ module Google
       generate_from_url(options[:url]) if options[:url]
       generate_from_file(options[:file]) if options[:file]
       generate_from_discovery(preferred_only: options[:preferred_only]) if options[:from_discovery]
-      create_file(options[:names_out]) { |*| generator.dump_api_names } if options[:names_out]
+      if options[:names_out]
+        create_file(options[:names_out]) { |*| generator.dump_api_names } unless File.exist? options[:names_out]
+      end
     end
 
     desc 'list', 'List public APIs'

--- a/bin/generate-api
+++ b/bin/generate-api
@@ -104,7 +104,7 @@ module Google
       end
 
       def generator
-        @generator ||= Google::Apis::Generator.new(api_names: options[:names])
+        @generator ||= Google::Apis::Generator.new(api_names: options[:names], api_names_out: options[:names_out])
       end
 
       def ensure_active_support


### PR DESCRIPTION
Pass the `names_out` value to the generator as the `api_names_out` argument. This is an attempt to resolve #623.