### PR TITLE
Replace mime-types dependency with mini_mime

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'representable', '~> 3.0'
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
-  spec.add_runtime_dependency 'mime-types', '~> 3.0'
+  spec.add_dependency 'mini_mime', '>= 0.1.1'
   spec.add_runtime_dependency 'signet', '~> 0.10'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.10.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'

--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'representable', '~> 3.0'
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'mini_mime', '>= 0.1.1'
+  spec.add_runtime_dependency 'mini_mime', '~> 1.0'
   spec.add_runtime_dependency 'signet', '~> 0.10'
   spec.add_runtime_dependency 'googleauth', '>= 0.5', '< 0.10.0'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'

--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -18,7 +18,7 @@ require 'google/apis/core/api_command'
 require 'google/apis/errors'
 require 'addressable/uri'
 require 'tempfile'
-require 'mime-types'
+require 'mini_mime'
 
 module Google
   module Apis
@@ -55,8 +55,8 @@ module Google
           elsif self.upload_source.is_a?(String)
             self.upload_io = File.new(upload_source, 'r')
             if self.upload_content_type.nil?
-              type = MIME::Types.of(upload_source)
-              self.upload_content_type = type.first.content_type unless type.nil? || type.empty?
+              type = MiniMime.lookup_by_filename(upload_source)
+              self.upload_content_type = type && type.content_type
             end
             @close_io_on_finish = true
           else


### PR DESCRIPTION
Replaced mime-types with mini_mime. Specs are passing.