### PR TITLE
docs: Add RubyDoc Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google API Client
+# Google API Client [![RubyDoc](https://img.shields.io/badge/RubyDoc-Google%3A%3AApis-red.svg)](https://www.rubydoc.info/github/googleapis/google-api-ruby-client/Google/Apis)
 
 These client libraries are officially supported by Google.  However, the libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues but will not add any new features.
 


### PR DESCRIPTION
Adds a Rubydoc badge so developers can view docs.

# Google API Client [![RubyDoc](https://img.shields.io/badge/RubyDoc-Google%3A%3AApis-red.svg)](https://www.rubydoc.info/github/googleapis/google-api-ruby-client/Google/Apis)