### PR TITLE
Convert query values explicitly to strings

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -156,7 +156,7 @@ module Google
             normalize_unicode = options.normalize_unicode
           end
           self.url = url.expand(params, nil, normalize_unicode) if url.is_a?(Addressable::Template)
-          url.query_values = query.merge(url.query_values || {})
+          url.query_values = normalize_query_values(query).merge(url.query_values || {})
 
           if allow_form_encoding?
             @form_encoded = true
@@ -419,6 +419,13 @@ module Google
           when 503 then 14 # UNAVAILABLE
           when 504 then 4 # DEADLINE_EXCEEDED
           else 2 # UNKNOWN
+          end
+        end
+
+        def normalize_query_values(input)
+          input.inject({}) do |h, (k, v)|
+            h[k] = normalize_query_value(v)
+            h
           end
         end
 

--- a/spec/google/apis/core/http_command_spec.rb
+++ b/spec/google/apis/core/http_command_spec.rb
@@ -419,6 +419,17 @@ RSpec.describe Google::Apis::Core::HttpCommand do
     command.execute(client)
   end
 
+  it 'should send DateTime query parameters' do
+    stub_request(:get, 'https://www.googleapis.com/zoo/animals?a=2019-06-22T13:51:37-07:00&b=2019-06-22T13:51:37-07:00&b=2019-07-23T14:54:12-07:00')
+      .to_return(status: [200, ''])
+    command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
+    date1 = DateTime.new(2019, 6, 22, 13, 51, 37, "-0700")
+    date2 = DateTime.new(2019, 7, 23, 14, 54, 12, "-0700")
+    command.query['a'] = date1
+    command.query['b'] = [date1, date2]
+    command.execute(client)
+  end
+
   it 'should form encode parameters when method is POST and no body present' do
     stub_request(:post, 'https://www.googleapis.com/zoo/animals')
         .with(body: 'a=1&a=2&a=3&b=hello&c=&d=0')


### PR DESCRIPTION
Ensure query parameters get converted explicitly to strings, to ensure there is proper support for passing `DateTime` and similar values to APIs. Fixes #755 