### PR TITLE
Support JSON serialization options for model objects

### DIFF
--- a/lib/google/apis/core/json_representation.rb
+++ b/lib/google/apis/core/json_representation.rb
@@ -145,7 +145,7 @@ module Google
 
         def to_json(*a)
           representation = self.class.const_get(:Representation)
-          representation.new(self).to_json(user_options: { skip_undefined: true })
+          representation.new(self).to_hash(user_options: { skip_undefined: true }).to_json(*a)
         end
       end
     end

--- a/spec/google/apis/core/json_representation_spec.rb
+++ b/spec/google/apis/core/json_representation_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
   end
 
   let(:model_class) do
+    rep_class = representer_class
     Class.new do
       attr_accessor :unset_value
       attr_accessor :nil_value
@@ -39,6 +40,8 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
       attr_accessor :items
       attr_accessor :child
       attr_accessor :children
+      const_set(:Representation, rep_class)
+      include Google::Apis::Core::JsonObjectSupport
     end
   end
 
@@ -150,6 +153,15 @@ RSpec.describe Google::Apis::Core::JsonRepresentation do
 
     include_examples 'it serializes'
 
+    it 'supports standard serialization from JSON gem' do
+      str = JSON.generate(model)
+      expect(str).to start_with("{\"")
+    end
+
+    it 'supports pretty serialization from JSON gem' do
+      str = JSON.pretty_generate(model)
+      expect(str).to start_with("{\n  ")
+    end
   end
 
   context 'with hash' do


### PR DESCRIPTION
Fixes #585 
Works around an issue with the `representable` gem where it doesn't pass JSON serialization options through its `to_json` implementation.