### PR TITLE
Clarify docs around authorization without Signet gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,38 @@ you're building an application that uses Google Compute Engine.
 
 For per-user authorization, use [Signet](https://github.com/google/signet) to obtain user authorization.
 
+### Authorization without Signet
+
+If you prefer to not use Signet, the `authorization` only needs to respond to `token` and `apply!`. Here's a simple adapter:
+
+```ruby
+class AccessToken
+  attr_reader :token
+  def initialize(token)
+    @token = token
+  end
+
+  def apply!(headers)
+    headers['Authorization'] = "Bearer #{@token}"
+  end
+end
+```
+
+### Authorization with OAuth2
+
+If you're using [`oauth2`](https://github.com/oauth-xx/oauth2), you can simply mixin the `apply!` method.
+
+```ruby
+module GoogleAuthorizationOAuth2AccessTokenPatch
+  def apply!(headers)
+    headers['Authorization'] = "Bearer #{token}"
+  end
+end
+
+# somewhere that's meaningful...
+OAuth2::AccessToken.include GoogleAuthorizationOAuth2AccessTokenPatch
+```
+
 ### Passing authorization to requests
 
 Authorization can be specified for the entire client, for an individual service instance, or on a per-request basis.


### PR DESCRIPTION
This PR clarifies how to provide authorization without using Signet. It pulls in some code from [here](https://github.com/googleapis/google-api-ruby-client/issues/296#issuecomment-147545845) and provides an example implementation for doing a mixin for OAuth.

I'm offering these docs because we spent the better part of an hour trying to figure it out (we had figured that Signet and OAuth2 gems were interchangeable), and would love to save other people's time in the future.