### PR TITLE
Ensure ClientSecrets uses googleauth extensions

### DIFF
--- a/lib/google/api_client/client_secrets.rb
+++ b/lib/google/api_client/client_secrets.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require 'json'
+require 'googleauth'
 
 
 module Google
@@ -147,8 +148,6 @@ module Google
       end
 
       def to_authorization
-        gem 'signet', '>= 0.4.0'
-        require 'signet/oauth_2/client'
         # NOTE: Do not rely on this default value, as it may change
         new_authorization = Signet::OAuth2::Client.new
         new_authorization.client_id = self.client_id


### PR DESCRIPTION
Ensure `googleauth` has loaded and its extensions to `signet` are in place when loading auth objects from `ClientSecrets`. Fixes #499 