### PR TITLE
Send x-goog-api-client header in all requests

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -52,6 +52,7 @@ module Google
         #
         # @return [void]
         def prepare!
+          set_xgac
           if options && options.api_format_version
             header['X-Goog-Api-Format-Version'] = options.api_format_version.to_s
           end
@@ -124,6 +125,17 @@ module Google
         end
 
         private
+
+        def set_xgac
+          old_xgac = header
+            .find_all { |k, v| k.downcase == 'x-goog-api-client' }
+            .map { |(a, b)| b }
+            .join(' ')
+          xgac = "gl-ruby/#{RUBY_VERSION} gdcl/#{Google::Apis::VERSION}"
+          xgac = old_xgac.empty? ? xgac : "#{old_xgac} #{xgac}"
+          header.delete_if { |k, v| k.downcase == 'x-goog-api-client' }
+          header['X-Goog-Api-Client'] = xgac
+        end
 
         # Attempt to parse a JSON error message
         # @param [String] body

--- a/spec/google/apis/core/api_command_spec.rb
+++ b/spec/google/apis/core/api_command_spec.rb
@@ -32,6 +32,33 @@ RSpec.describe Google::Apis::Core::ApiCommand do
     end
   end
 
+  let(:x_goog_api_client_value) { "gl-ruby/#{RUBY_VERSION} gdcl/#{Google::Apis::VERSION}" }
+
+  context('with preparation') do
+    let(:command) do
+      Google::Apis::Core::ApiCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
+    end
+
+    it 'should set X-Goog-Api-Client header if none is set' do
+      command.prepare!
+      expect(command.header['X-Goog-Api-Client']).to eql x_goog_api_client_value
+    end
+
+    it 'should append to x-goog-api-client header with case difference' do
+      command.header['x-goog-api-client'] = "foo/1.2.3"
+      command.prepare!
+      expect(command.header['X-Goog-Api-Client']).to eql "foo/1.2.3 #{x_goog_api_client_value}"
+    end
+
+    it 'should append to multiple x-goog-api-client headers' do
+      command.header['x-goog-api-client'] = "foo/1.2.3"
+      command.header['X-Goog-Api-Client'] = "bar/4.5.6"
+      command.prepare!
+      expect(command.header['X-Goog-Api-Client']).to eql "foo/1.2.3 bar/4.5.6 #{x_goog_api_client_value}"
+      expect(command.header['x-goog-api-client']).to be nil
+    end
+  end
+
   context('with a request body') do
     let(:command) do
       request = model_class.new

--- a/spec/google/apis/core/service_spec.rb
+++ b/spec/google/apis/core/service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Google::Apis::Core::BaseService do
   include TestHelpers
 
   let(:service) { Google::Apis::Core::BaseService.new('https://www.googleapis.com/', '') }
+  let(:x_goog_api_client_value) { "gl-ruby/#{RUBY_VERSION} gdcl/#{Google::Apis::VERSION}" }
 
   before do
     Google::Apis::ClientOptions.default.application_name = 'test'
@@ -120,6 +121,13 @@ RSpec.describe Google::Apis::Core::BaseService do
     it 'should build a correct URL' do
       url = command.url.expand({}).to_s
       expect(url).to eql 'https://www.googleapis.com/zoo/animals'
+    end
+
+    it 'should send the command with x-goog-api-client header' do
+      stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_return(body: '')
+      service.send(:execute_or_queue_command, command)
+      expected_headers = {'X-Goog-Api-Client': x_goog_api_client_value}
+      expect(a_request(:get, 'https://www.googleapis.com/zoo/animals').with(headers: expected_headers)).to have_been_made
     end
 
     include_examples 'with options'
@@ -269,10 +277,11 @@ EOF
 --outer
 Content-Type: application/http
 Content-Id: <b1981e17-f622-49af-b2eb-203308b1b17d+0>
-Content-Length: 303
+Content-Length: 349
 Content-Transfer-Encoding: binary
 
 POST /upload/zoo/animals? HTTP/1.1
+X-Goog-Api-Client: #{x_goog_api_client_value}
 Content-Type: multipart/related; boundary=inner
 X-Goog-Upload-Protocol: multipart
 Host: www.googleapis.com


### PR DESCRIPTION
Cause all API calls to set the X-Goog-Api-Client header, which is used for backend analytics.