### PR TITLE
Use auth objects for batch request auth

### DIFF
--- a/lib/google/apis/core/batch.rb
+++ b/lib/google/apis/core/batch.rb
@@ -163,6 +163,8 @@ module Google
         #   the serialized request
         def to_part(call)
           call.prepare!
+          # This will add the Authorization header if needed.
+          call.apply_request_options(call.header)
           parts = []
           parts << build_head(call)
           parts << build_body(call) unless call.body.nil?
@@ -177,8 +179,6 @@ module Google
           call.header.each do |key, value|
             request_head << sprintf("\r\n%s: %s", key, value)
           end
-          token = call.options.authorization
-          request_head << "\r\nAuthorization: Bearer #{token}" unless token.nil?
           request_head << sprintf("\r\nHost: %s", call.url.host)
           request_head << "\r\n\r\n"
           StringIO.new(request_head)


### PR DESCRIPTION
Supports OAuth token strings and googleauth/signet objects on individual batch calls by using `HttpCommand#apply_request_options` to add the Authorization header. Also add some test coverage for individual batch calls with auth set.


[closes #817]