### PR TITLE
fix: Customize name for an unsupported domainsrdap call

### DIFF
--- a/api_names.yaml
+++ b/api_names.yaml
@@ -711,6 +711,7 @@
 "/dns:v1/ChangesListResponse": list_changes_response
 "/dns:v1/ManagedZonesListResponse": list_managed_zones_response
 "/dns:v1/ResourceRecordSetsListResponse": list_resource_record_sets_response
+"/domainsrdap:v1/domainsrdap.ip.get": ip_get
 "/doubleclickbidmanager:v1/DownloadLineItemsRequest": download_line_items_request
 "/doubleclickbidmanager:v1/DownloadLineItemsResponse": download_line_items_response
 "/doubleclickbidmanager:v1/ListQueriesResponse": list_queries_response


### PR DESCRIPTION
Codegen has been failing since Aug 26 because two calls (`/domainsrdap:v1/domainsrdap.getIp` and `/domainsrdap:v1/domainsrdap.ip.get`) in the new domainsrdap client are mapping to the same method name (`get_ip`). Overriding the mapping of the latter to `ip_get`. (Note that according to the [documentation](https://developers.google.com/domains/rdap/reference/rest/v1/ip/get) this call is not supported anyway and always returns a 5xx.)