### PR TITLE
fix: Prevent upload requests from form-encoding their queries

### DIFF
--- a/lib/google/apis/core/upload.rb
+++ b/lib/google/apis/core/upload.rb
@@ -138,6 +138,10 @@ module Google
           @state = :start
           @upload_url = nil
           @offset = 0
+          # Prevent the command from populating the body with form encoding, by
+          # asserting that it already has a body. Form encoding is never used
+          # by upload requests.
+          self.body = '' unless self.body
           super
         end
 


### PR DESCRIPTION
If a resumable upload request has no associated JSON request document, initialize the request body to the empty string. This prevents HttpCommand from thinking that the intent is to form-encode the query parameters (which should never be done for upload requests).

Fixes #606.
