### PR TITLE
chore: add config for post job

### DIFF
--- a/.kokoro/continuous/post.cfg
+++ b/.kokoro/continuous/post.cfg
@@ -1,0 +1,30 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "google-api-ruby-client/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/multi-node
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-api-ruby-client/.kokoro/build.sh"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
+
+env_vars: {
+    key: "JOB_TYPE"
+    value: "post"
+}


### PR DESCRIPTION
- Runs linkinator against repo and ref docs on the "post" job every merge-to-master