### PR TITLE
fix: Remove duplicate clauses in X-Goog-Api-Client header

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -131,6 +131,9 @@ module Google
             .find_all { |k, v| k.downcase == 'x-goog-api-client' }
             .map { |(a, b)| b }
             .join(' ')
+            .split
+            .find_all { |s| s !~ %r{^gl-ruby/|^gdcl/} }
+            .join(' ')
           xgac = "gl-ruby/#{RUBY_VERSION} gdcl/#{Google::Apis::VERSION}"
           xgac = old_xgac.empty? ? xgac : "#{old_xgac} #{xgac}"
           header.delete_if { |k, v| k.downcase == 'x-goog-api-client' }

--- a/spec/google/apis/core/api_command_spec.rb
+++ b/spec/google/apis/core/api_command_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Google::Apis::Core::ApiCommand do
       expect(command.header['X-Goog-Api-Client']).to eql "foo/1.2.3 bar/4.5.6 #{x_goog_api_client_value}"
       expect(command.header['x-goog-api-client']).to be nil
     end
+
+    it 'should override existing gl-ruby/ and gdcl/ clauses' do
+      command.header['x-goog-api-client'] = "gl-ruby/0.0 foo/1.2.3"
+      command.header['X-Goog-Api-Client'] = "bar/4.5.6 gdcl/0.0"
+      command.prepare!
+      expect(command.header['X-Goog-Api-Client']).to eql "foo/1.2.3 bar/4.5.6 #{x_goog_api_client_value}"
+      expect(command.header['x-goog-api-client']).to be nil
+    end
   end
 
   context('with a request body') do


### PR DESCRIPTION
fixes #821 