### PR TITLE
Document Ruby compatibility change in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,6 @@
 
 # 0.33.0
 * Breaking changes:
-  * Dropped support for Ruby versions older than 2.4.
   * Deleted `urlshortener_v1`
 * Backwards compatible changes:
   * Updated `accessapproval_v1beta1`
@@ -175,6 +174,8 @@
   * Updated `serviceusage_v1`
   * Updated `serviceusage_v1beta1`
   * Updated `sheets_v4`
+* Other changes:
+  * Dropped support for Ruby versions older than 2.4
 
 # 0.32.1
 * Backwards compatible changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@
 
 # 0.33.0
 * Breaking changes:
-  * Dropped support for Ruby versions &lt; 2.4.
+  * Dropped support for Ruby versions older than 2.4.
   * Deleted `urlshortener_v1`
 * Backwards compatible changes:
   * Updated `accessapproval_v1beta1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 
 # 0.33.0
 * Breaking changes:
+  * Dropped support for Ruby versions &lt; 2.4.
   * Deleted `urlshortener_v1`
 * Backwards compatible changes:
   * Updated `accessapproval_v1beta1`


### PR DESCRIPTION
Hello! 👋 This is a quick addition to the changelog to document the recent change in Ruby support.

From what I've been able to verify, it looks like 0.33.0 was the last time Ruby < 2.4 was supported. Introduced in #834 and verified with:

```
$ git tag --contains bc573bf98 | head -n1
0.33.0
```