### PR TITLE
fix: Prevent OpenCensus integration from getting out of sync on upload commands

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -385,14 +385,16 @@ module Google
           return unless @opencensus_span
           return unless OpenCensus::Trace.span_context
 
-          if @http_res.body.respond_to? :bytesize
-            @opencensus_span.put_message_event \
-              OpenCensus::Trace::SpanBuilder::RECEIVED, 1, @http_res.body.bytesize
-          end
-          status = @http_res.status.to_i
-          if status > 0
-            @opencensus_span.set_status map_http_status status
-            @opencensus_span.put_attribute "http.status_code", status
+          if @http_res
+            if @http_res.body.respond_to? :bytesize
+              @opencensus_span.put_message_event \
+                OpenCensus::Trace::SpanBuilder::RECEIVED, 1, @http_res.body.bytesize
+            end
+            status = @http_res.status.to_i
+            if status > 0
+              @opencensus_span.set_status map_http_status status
+              @opencensus_span.put_attribute "http.status_code", status
+            end
           end
 
           OpenCensus::Trace.end_span @opencensus_span

--- a/spec/google/apis/core/upload_spec.rb
+++ b/spec/google/apis/core/upload_spec.rb
@@ -177,6 +177,16 @@ RSpec.describe Google::Apis::Core::ResumableUploadCommand do
       expect(a_request(:post, 'https://www.googleapis.com/zoo/animals')
         .with(body: 'Hello world')).to have_been_made
     end
+
+    it 'should generate a proper opencensus span' do
+      OpenCensus::Trace.start_request_trace do |span_context|
+        command.execute(client)
+        spans = span_context.build_contained_spans
+        expect(spans.size).to eql 1
+        span = spans.first
+        expect(span.name.value).to eql '/zoo/animals'
+      end
+    end
   end
 
   context 'with retriable error on start' do


### PR DESCRIPTION
The `ResumableUploadCommand` subclass does not use the normal `@http_res` result. As a result, `HttpCommand#opencensus_end_span` was throwing an internal exception and wasn't ending the span correctly, throwing the span stack out of sync and causing any caller's attempt to end the span to fail. This PR corrects the error.

Fixes #850 