### PR TITLE
decode_response_body empty body handling

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -87,6 +87,9 @@ module Google
           return super if content_type.nil?
           return nil unless content_type.start_with?(JSON_CONTENT_TYPE)
           instance = response_class.new
+          if body.empty?
+            body = '{}'
+          end
           response_representation.new(instance).from_json(body, unwrap: response_class)
           instance
         end


### PR DESCRIPTION
A more robust REST API response handling for empty body returns.
The rest API is not supposed to return an empty string since it's invalid JSON, but it can happen in some cases.
This change makes the decode_response_body method more robust to handle this case.