### PR TITLE
fix: temporarily disable Apigee V1 and resolve conflicts in Spanner V1.

### DIFF
--- a/api_list_config.yaml
+++ b/api_list_config.yaml
@@ -1,0 +1,2 @@
+blacklist:
+  - apigee.v1

--- a/api_list_config.yaml
+++ b/api_list_config.yaml
@@ -1,2 +1,2 @@
-blacklist:
+exclude:
   - apigee.v1

--- a/api_names.yaml
+++ b/api_names.yaml
@@ -965,6 +965,8 @@
 "/sheets:v4/sheets.spreadsheets.sheets.copyTo": copy_spreadsheet
 "/sheets:v4/sheets.spreadsheets.values.batchGet": batch_get_spreadsheet_values
 "/sheets:v4/sheets.spreadsheets.values.get": get_spreadsheet_values
+"/spanner:v1/spanner.projects.instances.backupOperations.list": list_project_instance_backupoperations
+"/spanner:v1/spanner.projects.instances.databaseOperations.list": list_project_instance_databaseoperations
 "/sqladmin:v1beta4/BackupRunsListResponse": list_backup_runs_response
 "/sqladmin:v1beta4/DatabasesListResponse": list_databases_response
 "/sqladmin:v1beta4/FlagsListResponse": list_flags_response

--- a/bin/generate-api
+++ b/bin/generate-api
@@ -78,10 +78,10 @@ module Google
       def generate_from_discovery(preferred_only: false)
         say 'Fetching API list'
         apis = discovery.list_apis
-        blacklist = api_list_config["blacklist"] || []
+        exclude_apis = api_list_config["exclude"] || []
         apis.items.each do |api|
-          if blacklist.include? "#{api.name}.#{api.version}"
-            say "Ignoring blacklisted API #{api.name} #{api.version}"
+          if exclude_apis.include? "#{api.name}.#{api.version}"
+            say "Ignoring excluded API #{api.name} #{api.version}"
           elsif (preferred_only && !api.preferred?)
             say sprintf('Ignoring disoverable API %s', api.id)
           else

--- a/bin/generate-api
+++ b/bin/generate-api
@@ -10,6 +10,7 @@ end
 require 'open-uri'
 require 'google/apis/discovery_v1'
 require 'logger'
+require 'psych'
 
 module Google
   class ApiGenerator < Thor
@@ -77,8 +78,11 @@ module Google
       def generate_from_discovery(preferred_only: false)
         say 'Fetching API list'
         apis = discovery.list_apis
+        blacklist = api_list_config["blacklist"] || []
         apis.items.each do |api|
-          if (preferred_only && !api.preferred?)
+          if blacklist.include? "#{api.name}.#{api.version}"
+            say "Ignoring blacklisted API #{api.name} #{api.version}"
+          elsif (preferred_only && !api.preferred?)
             say sprintf('Ignoring disoverable API %s', api.id)
           else
 	    # The Discovery service may returned cached versions of a Discovery document that are
@@ -107,6 +111,10 @@ module Google
 
       def generator
         @generator ||= Google::Apis::Generator.new(api_names: options[:names], api_names_out: options[:names_out])
+      end
+
+      def api_list_config
+        @api_list_config ||= Psych.load_file(__dir__ + "/../api_list_config.yaml")
       end
 
       def ensure_active_support

--- a/lib/google/apis/generator/annotator.rb
+++ b/lib/google/apis/generator/annotator.rb
@@ -76,7 +76,7 @@ module Google
         def pick_name(alt_name)
           preferred_name = @names[key]
           if preferred_name && preferred_name == alt_name
-            logger.warn { sprintf("Unnecessary name override '%s': %s", key, alt_name) }
+            # logger.warn { sprintf("Unnecessary name override '%s': %s", key, alt_name) }
           elsif preferred_name.nil?
             preferred_name = @names[key] = alt_name
           end


### PR DESCRIPTION
Apiary client generation has been broken for several weeks. The culprit, it appears, is the Apigee V1 discovery doc which is malformed. This PR adds a mechanism to temporarily blacklist individual APIs, and adds Apigee to that blacklist.

This also:
* Adds a couple of custom mappings for Spanner V1 which is currently experiencing name conflicts.
* Temporarily comments out a log message that is not very useful but is overwhelming the logs and making it difficult to see anything else. I'm leaving it commented for the time being rather than removing it outright, because I'm not yet sure what should be done in this case (e.g. whether this really is a warning case that should be paid attention to.)