### PR TITLE
Switch to safer Open3 to determine OS_VERSION

### DIFF
--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -26,7 +26,7 @@ module Google
         output, _ = Open3.capture2('ver')
         output.sub(/\s*\[Version\s*/, '/').sub(']', '')
       elsif RUBY_PLATFORM =~ /darwin/i
-        output, _ = Open3.capture2('sw_vers -productVersion')
+        output, _ = Open3.capture2('sw_vers', '-productVersion')
         "Mac OS X/#{output}"
       elsif RUBY_PLATFORM == 'java'
         require 'java'
@@ -34,7 +34,7 @@ module Google
         version = java.lang.System.getProperty('os.version')
         "#{name}/#{version}"
       else
-        output, _ = Open3.capture2('uname -sr')
+        output, _ = Open3.capture2('uname', '-sr')
         output.sub(' ', '/')
       end.strip
     rescue

--- a/lib/google/apis/version.rb
+++ b/lib/google/apis/version.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'open3'
+
 module Google
   module Apis
     # Client library version
@@ -21,16 +23,19 @@ module Google
     # @private
     OS_VERSION = begin
       if RUBY_PLATFORM =~ /mswin|win32|mingw|bccwin|cygwin/
-        `ver`.sub(/\s*\[Version\s*/, '/').sub(']', '')
+        output, _ = Open3.capture2('ver')
+        output.sub(/\s*\[Version\s*/, '/').sub(']', '')
       elsif RUBY_PLATFORM =~ /darwin/i
-        "Mac OS X/#{`sw_vers -productVersion`}"
+        output, _ = Open3.capture2('sw_vers -productVersion')
+        "Mac OS X/#{output}"
       elsif RUBY_PLATFORM == 'java'
         require 'java'
         name = java.lang.System.getProperty('os.name')
         version = java.lang.System.getProperty('os.version')
         "#{name}/#{version}"
       else
-        `uname -sr`.sub(' ', '/')
+        output, _ = Open3.capture2('uname -sr')
+        output.sub(' ', '/')
       end.strip
     rescue
       RUBY_PLATFORM


### PR DESCRIPTION
Closes: https://github.com/googleapis/google-api-ruby-client/issues/880
References: 
 - article stating the problems with using backticks https://www.hilman.io/blog/2016/01/stop-using-backtick-to-run-shell-command-in-ruby/
 - discussion about deprecating backticks in ruby 3 (even though the proposal was rejected it is an interesting read) https://bugs.ruby-lang.org/issues/14385

This PR updates `version.rb` to use the safer `Open3` instead of backticks which is vulnerable to command injection when determining the `OS_VERSION`.

