### PR TITLE
Re-enable Apigee V1 and make generation more robust against discovery errors

### DIFF
--- a/api_list_config.yaml
+++ b/api_list_config.yaml
@@ -1,2 +1,1 @@
-exclude:
-  - apigee.v1
+exclude: []

--- a/bin/generate-api
+++ b/bin/generate-api
@@ -59,7 +59,7 @@ module Google
         Array(urls).each do |url|
           begin
             json = discovery.http(:get, url)
-          rescue Google::Apis::ClientError
+          rescue Google::Apis::Error
             warn sprintf('Failed request, skipping %s', url)
             next
           end

--- a/script/generate
+++ b/script/generate
@@ -7,7 +7,6 @@ DIR=$(dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ))
 URLS=(https://content.googleapis.com/discovery/v1/apis/appsmarket/v2/rest \
       https://content.googleapis.com/discovery/v1/apis/youtubePartner/v1/rest \
       https://content.googleapis.com/discovery/v1/apis/compute/beta/rest \
-      https://developers.google.com/my-business/samples/mybusiness_google_rest_v3.json \
       https://monitoring.googleapis.com/\$discovery/rest?version=v3
 )
 


### PR DESCRIPTION
* Apigee V1 discovery doc has reportedly been fixed upstream, so removing it from the exclusion list.
* Generation has been failing for some time. The logs for yesterday's run suggest that we're getting a server error from discovery for some libraries, which currently is causing the entire generation run to abort. Instead, just skip the offending library to allow others to proceed.
* Remove an obsolete library from the list of "special" discovery URLs.