### PR TITLE
feat: Support custom quota_project in request options

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -52,12 +52,9 @@ module Google
         #
         # @return [void]
         def prepare!
-          set_xgac
-          if options&.authorization.respond_to? :quota_project_id
-            quota_project_id = options.authorization.quota_project_id
-            header['X-Goog-User-Project'] = quota_project_id if quota_project_id
-          end
-          if options && options.api_format_version
+          set_api_client_header
+          set_user_project_header
+          if options&.api_format_version
             header['X-Goog-Api-Format-Version'] = options.api_format_version.to_s
           end
           query[FIELDS_PARAM] = normalize_fields_param(query[FIELDS_PARAM]) if query.key?(FIELDS_PARAM)
@@ -130,7 +127,7 @@ module Google
 
         private
 
-        def set_xgac
+        def set_api_client_header
           old_xgac = header
             .find_all { |k, v| k.downcase == 'x-goog-api-client' }
             .map { |(a, b)| b }
@@ -142,6 +139,14 @@ module Google
           xgac = old_xgac.empty? ? xgac : "#{old_xgac} #{xgac}"
           header.delete_if { |k, v| k.downcase == 'x-goog-api-client' }
           header['X-Goog-Api-Client'] = xgac
+        end
+
+        def set_user_project_header
+          quota_project_id = options.quota_project
+          if !quota_project_id && options&.authorization.respond_to?(:quota_project_id)
+            quota_project_id = options.authorization.quota_project_id
+          end
+          header['X-Goog-User-Project'] = quota_project_id if quota_project_id
         end
 
         # Attempt to parse a JSON error message

--- a/lib/google/apis/options.rb
+++ b/lib/google/apis/options.rb
@@ -33,7 +33,8 @@ module Google
       :skip_serialization,
       :skip_deserialization,
       :api_format_version,
-      :use_opencensus)
+      :use_opencensus,
+      :quota_project)
 
     # General client options
     class ClientOptions
@@ -76,6 +77,8 @@ module Google
       #   @return [Fixnum] Version of the error format to request/expect.
       # @!attribute [rw] use_opencensus
       #   @return [Boolean] Whether OpenCensus spans should be generated for requests. Default is true.
+      # @!attribute [rw] quota_project
+      #   @return [String] Project ID to charge quota, or `nil` to default to the credentials-specified project.
 
       # Get the default options
       # @return [Google::Apis::RequestOptions]
@@ -105,5 +108,6 @@ module Google
     RequestOptions.default.skip_deserialization = false
     RequestOptions.default.api_format_version = nil
     RequestOptions.default.use_opencensus = true
+    RequestOptions.default.quota_project = nil
   end
 end

--- a/spec/google/apis/core/api_command_spec.rb
+++ b/spec/google/apis/core/api_command_spec.rb
@@ -71,10 +71,17 @@ RSpec.describe Google::Apis::Core::ApiCommand do
       expect(command.header['X-Goog-User-Project']).to be_nil
     end
 
-    it 'should set the X-Goog-User-Project to a given quota_project' do
+    it 'should set the X-Goog-User-Project to the credentials quota_project' do
       command.options.authorization = OpenStruct.new quota_project_id: "b_project_id"
       command.prepare!
       expect(command.header['X-Goog-User-Project']).to eql "b_project_id"
+    end
+
+    it 'should set the X-Goog-User-Project to a custom quota_project in preference to credentials' do
+      command.options.authorization = OpenStruct.new quota_project_id: "b_project_id"
+      command.options.quota_project = "c_project_id"
+      command.prepare!
+      expect(command.header['X-Goog-User-Project']).to eql "c_project_id"
     end
   end
 


### PR DESCRIPTION
Allow user override of the quota project via request option.

Part of a Q2 Yoshi OKR.