### PR TITLE
rexml is bundled gem in Ruby 3

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'signet', '~> 0.12'
   spec.add_runtime_dependency 'googleauth', '~> 0.9'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
+  spec.add_runtime_dependency 'rexml'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'activesupport', '>= 4.2', '< 5.1'
 end


### PR DESCRIPTION
Refer this pull request and the discussion:

- Remove rexml and rss
https://github.com/ruby/ruby/pull/2832

- Feature #16485
https://bugs.ruby-lang.org/issues/16485
> Cons: The users need to add rexml to their Gemfile after Ruby 2.8(3.0)

Fixes #871