### PR TITLE
Allow Ruby 3

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib generated]
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_runtime_dependency 'representable', '~> 3.0'
   spec.add_runtime_dependency 'retriable', '>= 2.0', '< 4.0'


### PR DESCRIPTION
The version of ruby HEAD is now 3.0.0dev, so please allow Ruby 3.
