### PR TITLE
update googleauth dependency

### DIFF
--- a/google-api-client.gemspec
+++ b/google-api-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_runtime_dependency 'mini_mime', '~> 1.0'
   spec.add_runtime_dependency 'signet', '~> 0.12'
-  spec.add_runtime_dependency 'googleauth', '~> 0.9'
+  spec.add_runtime_dependency 'googleauth', '~> 0.11'
   spec.add_runtime_dependency 'httpclient', '>= 2.8.1', '< 3.0'
   spec.add_development_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'activesupport', '>= 4.2', '< 5.1'


### PR DESCRIPTION
googleauth 0.11 is the first one that can use faraday 1.0:  faraday >= 0.17.3, < 2.0

could we please update this so the folk at manageiq could use the newer faraday? 

thanks