### PR TITLE
fix: Fix JSON parser crash if an empty body (such as HTTP 204) is received

### DIFF
--- a/lib/google/apis/core/api_command.rb
+++ b/lib/google/apis/core/api_command.rb
@@ -83,6 +83,7 @@ module Google
           return super if options && options.skip_deserialization
           return super if content_type.nil?
           return nil unless content_type.start_with?(JSON_CONTENT_TYPE)
+          body = "{}" if body.empty?
           instance = response_class.new
           response_representation.new(instance).from_json(body, unwrap: response_class)
           instance


### PR DESCRIPTION
Should fix #864 