### PR TITLE
feat: Add query to RequestOptions

### DIFF
--- a/lib/google/apis/core/http_command.rb
+++ b/lib/google/apis/core/http_command.rb
@@ -145,7 +145,7 @@ module Google
           options.authorization.respond_to?(:apply!)
         end
 
-        # Prepare the request (e.g. calculate headers, serialize data, etc) before sending
+        # Prepare the request (e.g. calculate headers, add query params, serialize data, etc) before sending
         #
         # @private
         # @return [void]
@@ -153,6 +153,7 @@ module Google
           normalize_unicode = true
           if options
             header.update(options.header) if options.header
+            query.update(options.query) if options.query
             normalize_unicode = options.normalize_unicode
           end
           self.url = url.expand(params, nil, normalize_unicode) if url.is_a?(Addressable::Template)

--- a/lib/google/apis/options.rb
+++ b/lib/google/apis/options.rb
@@ -34,7 +34,8 @@ module Google
       :skip_deserialization,
       :api_format_version,
       :use_opencensus,
-      :quota_project)
+      :quota_project,
+      :query)
 
     # General client options
     class ClientOptions
@@ -62,13 +63,13 @@ module Google
     # Request options
     class RequestOptions
       # @!attribute [rw] authorization
-      #   @return [Signet::OAuth2::Client, #apply(Hash)] OAuth2 credentials
+      #   @return [Signet::OAuth2::Client, #apply(Hash)] OAuth2 credentials.
       # @!attribute [rw] retries
-      #   @return [Fixnum] Number of times to retry requests on server error
+      #   @return [Fixnum] Number of times to retry requests on server error.
       # @!attribute [rw] header
-      #   @return [Hash<String,String] Additional HTTP headers to include in requests
+      #   @return [Hash<String,String>] Additional HTTP headers to include in requests.
       # @!attribute [rw] normalize_unicode
-      #   @return [Boolean] True if unicode strings should be normalized in path parameters
+      #   @return [Boolean] True if unicode strings should be normalized in path parameters.
       # @!attribute [rw] skip_serialization
       #   @return [Boolean] True if body object should be treated as raw text instead of an object.
       # @!attribute [rw] skip_deserialization
@@ -79,6 +80,8 @@ module Google
       #   @return [Boolean] Whether OpenCensus spans should be generated for requests. Default is true.
       # @!attribute [rw] quota_project
       #   @return [String] Project ID to charge quota, or `nil` to default to the credentials-specified project.
+      # @!attribute [rw] query
+      #   @return [Hash<String,String>] Additional HTTP URL query parameters to include in requests.
 
       # Get the default options
       # @return [Google::Apis::RequestOptions]

--- a/spec/google/apis/core/http_command_spec.rb
+++ b/spec/google/apis/core/http_command_spec.rb
@@ -442,6 +442,17 @@ RSpec.describe Google::Apis::Core::HttpCommand do
     command.execute(client)
   end
 
+  it 'should prepend user query parameters from options and not remove initial query parameters', :focus do
+    stub_request(:get, 'https://www.googleapis.com/zoo/animals?a=1&a=2&a=3&b=false&foo=bar')
+      .to_return(status: [200, ''])
+    command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals?foo=bar')
+    command.options.query = {
+      'a' => [1,2,3],
+      'b' => false
+    }
+    command.execute(client)
+  end
+
   it 'should raise transmission error instead of socket error' do
     stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_raise(SocketError)
     command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')


### PR DESCRIPTION
Expose the ability for the user to configure HTTP URL parameters to be sent with every request.

#### Example:

```rb
service = API::BigqueryService.new
service.request_options.query ||= {}
service.request_options.query["prettyPrint"] = false
```

refs: googleapis/google-cloud-ruby#7806