### PR TITLE
chore: Configure release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+on:
+  # schedule:
+  #   - cron: '49 8 * * 1'
+  workflow_dispatch:
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2.5.6
+        with:
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          release-type: ruby
+          package-name: google-api-ruby-client
+          version-file: lib/google/apis/version.rb
+          monorepo-tags: true
+          bump-minor-pre-major: true


### PR DESCRIPTION
Configure release-please for this repo.

Although this repo currently includes only one gem, it is configured as a monorepo (and hence its tag format includes a package name, which is currently set to `google-api-ruby-client` as a pseudonym). This is because it will shortly be broken out into multiple gems.

This workflow will eventually run on a weekly cron (rather than on every push to the main branch). However, this PR disables the cron temporarily, until I have the chance to test the workflow manually.