### PR TITLE
Fix README.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ document = docs_service.get_document("my-document-id")
 See the [samples](https://github.com/google/google-api-ruby-client/tree/master/samples) for examples on how to use the client library for various
 services.
 
-Contributions for additional samples are welcome. See [CONTRIBUTING](CONTRIBUTING.md).
+Contributions for additional samples are welcome. See [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 ## Generating APIs
 
@@ -378,7 +378,7 @@ A URL can also be specified:
 *  Model validations
 
 ## Supported Ruby Versions
-This library is currently supported on Ruby 1.9+.  
+This library is currently supported on Ruby 1.9+.
 However, Ruby 2.4 or later is strongly recommended, as earlier releases have
 reached or are nearing end-of-life. After March 31, 2019, Google will provide
 official support only for Ruby versions that are considered current and


### PR DESCRIPTION
In README.md, the link destination of "CONTRIBUTING" was incorrect (404 error), so I fixed it.