### PR TITLE
chore: Update release-please jobs to reference separate gems

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,0 +1,58 @@
+on:
+  schedule:
+    - cron: '29 8 * * 1'
+  workflow_dispatch:
+
+name: release-core
+jobs:
+  release-please:
+    env:
+      ENABLE_AUTO_APPROVE: ${{ secrets.ENABLE_AUTO_APPROVE }}
+      ENABLE_RELEASE_PLEASE: ${{ secrets.ENABLE_RELEASE_PLEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: ReleasePlease
+        id: release-please
+        if: ${{ env.ENABLE_RELEASE_PLEASE }}
+        uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          command: release-pr
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          fork: true
+          release-type: ruby
+          path: google-apis-core
+          package-name: google-apis-core
+          version-file: lib/google/apis/core/version.rb
+          monorepo-tags: true
+          bump-minor-pre-major: true
+      - name: AutoApprove
+        id: auto-approve
+        if: ${{ steps.release-please.outputs.pr }}
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
+          script: |
+            if (process.env.ENABLE_AUTO_APPROVE) {
+              core.info("ENABLE_AUTO_APPROVE is set; labeling and approving");
+              github.pulls.createReview({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                body: "AutoApprove: Rubber stamped release!",
+                pull_number: ${{ steps.release-please.outputs.pr }},
+                event: "APPROVE"
+              });
+              github.issues.addLabels({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                issue_number: ${{ steps.release-please.outputs.pr }},
+                labels: ["autorelease: pending", "automerge", "kokoro:force-run"]
+              });
+            } else {
+              core.info("ENABLE_AUTO_APPROVE is not set; labeling release only");
+              github.issues.addLabels({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                issue_number: ${{ steps.release-please.outputs.pr }},
+                labels: ["autorelease: pending", "kokoro:force-run"]
+              });
+            }

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -1,0 +1,58 @@
+on:
+  schedule:
+    - cron: '39 8 * * 1'
+  workflow_dispatch:
+
+name: release-generator
+jobs:
+  release-please:
+    env:
+      ENABLE_AUTO_APPROVE: ${{ secrets.ENABLE_AUTO_APPROVE }}
+      ENABLE_RELEASE_PLEASE: ${{ secrets.ENABLE_RELEASE_PLEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: ReleasePlease
+        id: release-please
+        if: ${{ env.ENABLE_RELEASE_PLEASE }}
+        uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          command: release-pr
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          fork: true
+          release-type: ruby
+          path: google-apis-generator
+          package-name: google-apis-generator
+          version-file: lib/google/apis/generator/version.rb
+          monorepo-tags: true
+          bump-minor-pre-major: true
+      - name: AutoApprove
+        id: auto-approve
+        if: ${{ steps.release-please.outputs.pr }}
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
+          script: |
+            if (process.env.ENABLE_AUTO_APPROVE) {
+              core.info("ENABLE_AUTO_APPROVE is set; labeling and approving");
+              github.pulls.createReview({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                body: "AutoApprove: Rubber stamped release!",
+                pull_number: ${{ steps.release-please.outputs.pr }},
+                event: "APPROVE"
+              });
+              github.issues.addLabels({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                issue_number: ${{ steps.release-please.outputs.pr }},
+                labels: ["autorelease: pending", "automerge", "kokoro:force-run"]
+              });
+            } else {
+              core.info("ENABLE_AUTO_APPROVE is not set; labeling release only");
+              github.issues.addLabels({
+                owner: 'googleapis',
+                repo: 'google-api-ruby-client',
+                issue_number: ${{ steps.release-please.outputs.pr }},
+                labels: ["autorelease: pending", "kokoro:force-run"]
+              });
+            }

--- a/.github/workflows/release-umbrella.yml
+++ b/.github/workflows/release-umbrella.yml
@@ -3,7 +3,7 @@ on:
     - cron: '49 8 * * 1'
   workflow_dispatch:
 
-name: release-please
+name: release-umbrella
 jobs:
   release-please:
     env:
@@ -20,7 +20,8 @@ jobs:
           token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
           fork: true
           release-type: ruby
-          package-name: google-api-ruby-client
+          path: google-api-client
+          package-name: google-api-client
           version-file: lib/google/apis/version.rb
           monorepo-tags: true
           bump-minor-pre-major: true


### PR DESCRIPTION
Previously, this repo had a single package located at the root. Now we have multiple packages located in subdirectories.

This PR modifies the release-please GitHub actions to cover the three packages that will be managed via release-please. The new actions are mostly the same as the original action, except the package names have been changed, and I've set the `path` parameter, which I assume tells release-please to limit its commit search to that subdirectory. (@bcoe is that right?)
