### PR TITLE
Add cause's class to Google::Apis::Error message

### DIFF
--- a/google-apis-core/lib/google/apis/errors.rb
+++ b/google-apis-core/lib/google/apis/errors.rb
@@ -24,7 +24,7 @@ module Google
         @cause = nil
 
         if err.respond_to?(:backtrace)
-          super(err.message)
+          super("caused by #{err.class}: #{err.message}")
           @cause = err
         else
           super(err.to_s)

--- a/google-apis-core/spec/google/apis/errors_spec.rb
+++ b/google-apis-core/spec/google/apis/errors_spec.rb
@@ -30,10 +30,11 @@ RSpec.describe Google::Apis::Error do
       context 'first arg responds to :backtrace' do
         let(:error) { double }
 
-        it 'creates a instance of Error with message' do
+        it 'creates a instance of Error with modified message' do
           allow(error).to receive(:respond_to?).with(:backtrace) { true }
           allow(error).to receive(:message) { 'error message' }
-          expect(subject.message).to eq 'error message'
+		  allow(error).to receive(:class) { 'TestError' }
+          expect(subject.message).to eq 'caused by TestError: error message'
         end
       end
     end


### PR DESCRIPTION
Knowing what the original error that was thrown was can be useful, and it would be nice to be able to know at a glance when one of these errors is raised.