### PR TITLE
delete unused variable

### DIFF
--- a/google-apis-core/lib/google/apis/core/batch.rb
+++ b/google-apis-core/lib/google/apis/core/batch.rb
@@ -168,7 +168,6 @@ module Google
           parts = []
           parts << build_head(call)
           parts << build_body(call) unless call.body.nil?
-          length = parts.inject(0) { |a, e| a + e.length }
           Google::Apis::Core::CompositeIO.new(*parts)
         end
 


### PR DESCRIPTION
The following warnings have been suppressed

```
/usr/local/bundle/gems/google-apis-core-0.3.0/lib/google/apis/core/batch.rb:171: warning: assigned but unused variable - length
```