### PR TITLE
Enable frozen_string_literals

### DIFF
--- a/google-apis-generator/lib/google/apis/generator/templates/classes.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/classes.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/entry-point.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/entry-point.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/gemfile.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/gemfile.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("lib/<%= api.base_path %>/gem_version", __dir__)
 
 Gem::Specification.new do |gem|

--- a/google-apis-generator/lib/google/apis/generator/templates/generated_spec.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/generated_spec.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/initial-gem_version.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/initial-gem_version.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/module.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/module.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/rakefile.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/rakefile.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 task :release_gem do
   Rake::Task["build"].invoke

--- a/google-apis-generator/lib/google/apis/generator/templates/representations.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/representations.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google-apis-generator/lib/google/apis/generator/templates/service.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/service.rb.tmpl
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The generated code contains quite a lot of duplicated string literals. Enabling frozen string literals would reduce the memory footprint a little bit.

NB: I didn't run the generator script because it would generate a massive diff, and from what I can see a bot does it on master on a regular basis.