### PR TITLE
chore: add .repo-metadata.json files to the three handwritten libs

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,0 @@
-{
-    "name": "google-api-client",
-    "language": "ruby",
-    "distribution-name": "google-api-client"
-}

--- a/google-api-client/.repo-metadata.json
+++ b/google-api-client/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+    "name": "google-api-client",
+    "language": "ruby",
+    "distribution-name": "google-api-client",
+    "library_type": "OTHER"
+}

--- a/google-api-client/.repo-metadata.json
+++ b/google-api-client/.repo-metadata.json
@@ -1,6 +1,5 @@
 {
-    "name": "google-api-client",
-    "language": "ruby",
     "distribution-name": "google-api-client",
+    "language": "ruby",
     "library_type": "OTHER"
 }

--- a/google-apis-core/.repo-metadata.json
+++ b/google-apis-core/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "google-apis-core",
+  "language": "ruby",
+  "distribution-name": "google-apis-core",
+  "library_type": "CORE"
+}

--- a/google-apis-core/.repo-metadata.json
+++ b/google-apis-core/.repo-metadata.json
@@ -1,6 +1,5 @@
 {
-  "name": "google-apis-core",
-  "language": "ruby",
   "distribution-name": "google-apis-core",
+  "language": "ruby",
   "library_type": "CORE"
 }

--- a/google-apis-generator/.repo-metadata.json
+++ b/google-apis-generator/.repo-metadata.json
@@ -1,6 +1,5 @@
 {
-  "name": "google-apis-generator",
-  "language": "ruby",
   "distribution-name": "google-apis-generator",
+  "language": "ruby",
   "library_type": "OTHER"
 }

--- a/google-apis-generator/.repo-metadata.json
+++ b/google-apis-generator/.repo-metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "google-apis-generator",
+  "language": "ruby",
+  "distribution-name": "google-apis-generator",
+  "library_type": "OTHER"
+}


### PR DESCRIPTION
Deleted the .repo-metadata.json from the root and add them to the three handwritten libs(core, client, and generator). This is part of internal issue #184315365.