### PR TITLE
fix(core): Expand googleauth dependency to include future 1.x versions

### DIFF
--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -20,12 +20,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "representable", "~> 3.0"
-  gem.add_runtime_dependency "retriable", ">= 2.0", "< 4.0"
+  gem.add_runtime_dependency "retriable", ">= 2.0", "< 4.a"
   gem.add_runtime_dependency "addressable", "~> 2.5", ">= 2.5.1"
   gem.add_runtime_dependency "mini_mime", "~> 1.0"
-  gem.add_runtime_dependency "signet", "~> 0.14"
-  gem.add_runtime_dependency "googleauth", "~> 0.14"
-  gem.add_runtime_dependency "httpclient", ">= 2.8.1", "< 3.0"
+  gem.add_runtime_dependency "googleauth", ">= 0.16.2", "< 2.a"
+  gem.add_runtime_dependency "httpclient", ">= 2.8.1", "< 3.a"
   gem.add_runtime_dependency "rexml"
   gem.add_runtime_dependency "webrick"
 end


### PR DESCRIPTION
We've been asked to bump googleauth to 1.0. In preparation, we're expanding all googleauth dependencies to support both 0.x and 1.x.