### PR TITLE
Update overview.md.tmpl - client only has `authorization=` method, no `authentication=`

### DIFF
--- a/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
@@ -51,7 +51,7 @@ require "<%= api.base_path %>"
 client = <%= api.qualified_name %>::<%= api.service_name %>.new
 
 # Authenticate calls
-client.authentication = # ... use the googleauth gem to create credentials
+client.authorization = # ... use the googleauth gem to create credentials
 ```
 
 See the class reference docs for information on the methods you can call from a client.


### PR DESCRIPTION
`client` only has a [authorization=](https://github.com/googleapis/google-api-ruby-client/blob/main/google-apis-core/lib/google/apis/core/base_service.rb#L151) method,  no `authentication` method. So, here, it guess it should be `authorization`