### PR TITLE
Support configuration of max elapsed time of requests

### DIFF
--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -100,6 +100,7 @@ module Google
           opencensus_begin_span
           begin
             Retriable.retriable tries: options.retries + 1,
+                                max_elapsed_time: options.max_elapsed_time,
                                 base_interval: 1,
                                 multiplier: 2,
                                 on: RETRIABLE_ERRORS do |try|

--- a/google-apis-core/lib/google/apis/options.rb
+++ b/google-apis-core/lib/google/apis/options.rb
@@ -28,6 +28,7 @@ module Google
     RequestOptions = Struct.new(
       :authorization,
       :retries,
+      :max_elapsed_time,
       :header,
       :normalize_unicode,
       :skip_serialization,
@@ -66,6 +67,8 @@ module Google
       #   @return [Signet::OAuth2::Client, #apply(Hash)] OAuth2 credentials.
       # @!attribute [rw] retries
       #   @return [Fixnum] Number of times to retry requests on server error.
+      # @!attribute [rw] max_elapsed_time
+      #   @return [Fixnum] Total time in seconds that requests are allowed to keep being retried.
       # @!attribute [rw] header
       #   @return [Hash<String,String>] Additional HTTP headers to include in requests.
       # @!attribute [rw] normalize_unicode
@@ -106,6 +109,7 @@ module Google
     ClientOptions.default.application_version = '0.0.0'
     ClientOptions.default.transparent_gzip_decompression = true
     RequestOptions.default.retries = 0
+    RequestOptions.default.max_elapsed_time = 900
     RequestOptions.default.normalize_unicode = false
     RequestOptions.default.skip_serialization = false
     RequestOptions.default.skip_deserialization = false

--- a/google-apis-core/spec/google/apis/core/http_command_spec.rb
+++ b/google-apis-core/spec/google/apis/core/http_command_spec.rb
@@ -147,6 +147,18 @@ RSpec.describe Google::Apis::Core::HttpCommand do
     it 'should call block if present' do
       expect { |b| command.execute(client, &b) }.to yield_with_args('Hello world', nil)
     end
+
+    it 'should retry with max elapsed_time and retries' do
+      expect(Retriable).to receive(:retriable).with(
+        tries: Google::Apis::RequestOptions.default.retries + 1,
+        max_elapsed_time: Google::Apis::RequestOptions.default.max_elapsed_time,
+        base_interval: 1,
+        multiplier: 2,
+        on: described_class::RETRIABLE_ERRORS).and_call_original
+      allow(Retriable).to receive(:retriable).and_call_original
+
+      command.execute(client)
+    end
   end
 
   context('with server errors') do

--- a/google-apis-core/spec/google/apis/options_spec.rb
+++ b/google-apis-core/spec/google/apis/options_spec.rb
@@ -17,6 +17,7 @@ require 'google/apis/options'
 
 RSpec.describe Google::Apis::RequestOptions do
   let(:options) { Google::Apis::RequestOptions.new }
+  let(:defaults) { described_class.default }
 
   it 'should not merge nil values' do
     options.retries = 1
@@ -37,4 +38,15 @@ RSpec.describe Google::Apis::RequestOptions do
   it 'should allow nil in merge' do
     expect(options.merge(nil)).to be_an_instance_of(Google::Apis::RequestOptions)
   end
+
+  it 'sets default values' do
+    expect(defaults.retries).to eq(5) # Overriden in spec_helper.rb
+    expect(defaults.max_elapsed_time).to eq(900)
+    expect(defaults.normalize_unicode).to be false
+    expect(defaults.skip_serialization).to be false
+    expect(defaults.skip_deserialization).to be false
+    expect(defaults.api_format_version).to be nil
+    expect(defaults.use_opencensus).to be true
+    expect(defaults.quota_project).to be_nil
+ end
 end


### PR DESCRIPTION
By default, the Retriable gem sets `max_elapsed_time` to 15
minutes. This can result in large transfers being aborted prematurely
rather than being retried. Make it possible to configure this value in
case the default is too low.

Closes https://github.com/googleapis/google-api-ruby-client/issues/690