### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-latest
             ruby: "3.0"
             task: "--include-spec"
+          - os: ubuntu-latest
+            ruby: "3.1"
+            task: "--include-spec"
           - os: macos-latest
             ruby: "2.7"
             task: "--include-spec"


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.