### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   CI:
     if: ${{ github.repository == 'googleapis/google-api-ruby-client' }}

--- a/.github/workflows/daily-generate-updates.yml
+++ b/.github/workflows/daily-generate-updates.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '02 11 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   generate-updates:
     if: ${{ github.repository == 'googleapis/google-api-ruby-client' }}

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -6,6 +6,9 @@ on:
         description: "Extra command line arguments."
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   generate-updates:
     if: ${{ github.repository == 'googleapis/google-api-ruby-client' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,9 @@ on:
         description: "Extra command line arguments."
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     if: ${{ github.repository == 'googleapis/google-api-ruby-client' }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
