### PR TITLE
Remove rexml as a runtime dependency

### DIFF
--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mini_mime", "~> 1.0"
   gem.add_runtime_dependency "googleauth", ">= 0.16.2", "< 2.a"
   gem.add_runtime_dependency "httpclient", ">= 2.8.1", "< 3.a"
-  gem.add_runtime_dependency "rexml"
   gem.add_runtime_dependency "webrick"
 end


### PR DESCRIPTION
This was added in 660a79807ab250b4e95179247e00ee8a364b9ce1 (see https://github.com/googleapis/google-api-ruby-client/issues/871 as well), but I can't reproduce the failure. I also can't find out where rexml was used in the past.