### PR TITLE
Revert "Properly log errors as errors"

### DIFF
--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -275,7 +275,7 @@ module Google
         # @yield [nil, err] if block given
         # @raise [StandardError] if no block
         def error(err, rethrow: false, &block)
-          logger.error { sprintf('Error - %s', PP.pp(err, '')) }
+          logger.debug { sprintf('Error - %s', PP.pp(err, '')) }
           if err.is_a?(HTTPClient::BadResponseError)
             begin
               res = err.res


### PR DESCRIPTION
Reverts googleapis/google-api-ruby-client#6494