### PR TITLE
fix(core): Storage upload to handle empty string/file cases

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -139,7 +139,7 @@ module Google
           current_chunk_size = remaining_content_size < CHUNK_SIZE ? remaining_content_size : CHUNK_SIZE
 
           request_header = header.dup
-          request_header[CONTENT_RANGE_HEADER] = sprintf('bytes %d-%d/%d', @offset, @offset+current_chunk_size-1, upload_io.size)
+          request_header[CONTENT_RANGE_HEADER] = get_content_range_header current_chunk_size
           request_header[CONTENT_LENGTH_HEADER] = current_chunk_size
           chunk_body = upload_io.read(current_chunk_size)
 
@@ -174,6 +174,15 @@ module Google
 
         def streamable?(upload_source)
           upload_source.is_a?(IO) || upload_source.is_a?(StringIO) || upload_source.is_a?(Tempfile)
+        end
+
+        def get_content_range_header current_chunk_size
+          if upload_io.size == 0
+            numerator = "*"
+          else
+            numerator = sprintf("%d-%d", @offset, @offset+current_chunk_size-1)
+          end
+          sprintf('bytes %s/%d', numerator, upload_io.size)
         end
       end
     end

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
     include_examples 'should upload'
   end
 
+  context('with empty StringIO input') do
+    let(:file) { StringIO.new("") }
+    include_examples 'should upload'
+  end
+
   context('with IO input') do
     let(:file) { File.open(File.join(FIXTURES_DIR, 'files', 'test.txt'), 'r') }
     include_examples 'should upload'
@@ -79,6 +84,11 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
     it 'should not close stream' do
       expect(file.closed?).to be false
     end
+  end
+
+  context 'with empty Tempfile' do
+    let(:file) { Tempfile.new {} }
+    include_examples 'should upload'    
   end
 
   context('with file path input') do


### PR DESCRIPTION
Fixes [#19246](https://github.com/googleapis/google-cloud-ruby/issues/19246)