### PR TITLE
remove: Unused variable

### DIFF
--- a/google-apis-core/lib/google/apis/core/batch.rb
+++ b/google-apis-core/lib/google/apis/core/batch.rb
@@ -169,7 +169,6 @@ module Google
           parts = []
           parts << build_head(call)
           parts << build_body(call) unless call.body.nil?
-          length = parts.inject(0) { |a, e| a + e.length }
           Google::Apis::Core::CompositeIO.new(*parts)
         end
 


### PR DESCRIPTION
The `length` variable is defined but never used.

This variable had been unused since 2017.
ref: https://github.com/googleapis/google-api-ruby-client/pull/564