### PR TITLE
fix: Replace `File.exists?` with `File.exist?`

### DIFF
--- a/google-apis-core/lib/google/api_client/client_secrets.rb
+++ b/google-apis-core/lib/google/api_client/client_secrets.rb
@@ -61,7 +61,7 @@ module Google
         end
         while filename == nil
           search_path ||= File.expand_path('.')
-          if File.exists?(File.join(search_path, 'client_secrets.json'))
+          if File.exist?(File.join(search_path, 'client_secrets.json'))
             filename = File.join(search_path, 'client_secrets.json')
           elsif search_path == File.expand_path('..', search_path)
             raise ArgumentError,


### PR DESCRIPTION
File.exists? will be removed in Ruby 3.2.

https://www.ruby-lang.org/en/news/2022/11/11/ruby-3-2-0-preview3-released/