### PR TITLE
fix: Improve upload performance

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -15,6 +15,7 @@
 require 'google/apis/core/http_command'
 require 'google/apis/core/api_command'
 require 'google/apis/errors'
+require 'stringio'
 require 'tempfile'
 require 'mini_mime'
 
@@ -141,7 +142,7 @@ module Google
           request_header = header.dup
           request_header[CONTENT_RANGE_HEADER] = get_content_range_header current_chunk_size
           request_header[CONTENT_LENGTH_HEADER] = current_chunk_size
-          chunk_body = upload_io.read(current_chunk_size)
+          chunk_body = StringIO.new(upload_io.read(current_chunk_size))
 
           response = client.put(@upload_url, body: chunk_body, header: request_header, follow_redirect: true)
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -39,12 +39,15 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
     end
 
     it 'should send upload command' do
+      allow(client).to receive(:put).and_call_original
+      expect(client).to receive(:put).with(anything, hash_including(body: kind_of(StringIO)))
+
       command.execute(client)
       expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
         .with { |req| req.headers['Content-Length'].include?('11') }).to have_been_made
 
       expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-        .with { |req| req.headers['Content-Type'].include?('application/json') }).to have_been_made      
+        .with { |req| req.headers['Content-Type'].include?('application/json') }).to have_been_made
 
       expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
         .with{ |req| req.headers['Content-Length'].include?('11')}).to have_been_made


### PR DESCRIPTION
The change in #11508 introduced a significant performance
regression. It caused the HTTP client to read 8 MB chunks from the
upload source and send each chunk in separate PUT requests with a
String object instead of an IO object. This significantly slowed
upload performance since the SSL socket sends 16K at a time and
resizes the String buffer with each iteration. This caused CPU to
skyrocket since it requires allocating a new buffer and copying
existing data into that string. The garbage collector would have to
work hard to keep up.                                                                                                                                                            
                                                                                                                                                                                               
To eliminate this unnecessary String resizing, wrap the read chunk in                                                                                                                          
a `StringIO` object. This enables `OpenSSL::Buffering` to read and                                                                                                                             
write a full 16K buffer.                                                                                                                                                                       

Relates to #13212