### PR TITLE
storage: Optimize memory usage when upload chunk size is set to 0

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -146,7 +146,12 @@ module Google
           request_header = header.dup
           request_header[CONTENT_RANGE_HEADER] = get_content_range_header current_chunk_size
           request_header[CONTENT_LENGTH_HEADER] = current_chunk_size
-          chunk_body = StringIO.new(upload_io.read(current_chunk_size))
+          chunk_body =
+            if @upload_chunk_size == 0
+              upload_io
+            else
+              StringIO.new(upload_io.read(current_chunk_size))
+            end
 
           response = client.put(@upload_url, body: chunk_body, header: request_header, follow_redirect: true)
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -130,10 +130,12 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
   end
 
   context('with chunking disabled') do
-    let(:file) { StringIO.new("Hello world")}
+    let!(:file) { StringIO.new("Hello world")}
     include_examples 'should upload'
 
     it 'should upload content in one request' do
+      expect(StringIO).not_to receive(:new)
+
       command.options.upload_chunk_size = 0
       command.execute(client)
       expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')


### PR DESCRIPTION
https://github.com/googleapis/google-api-ruby-client/pull/13283 added support for disabling upload chunking. However, when chunking is disabled, the upload attempts to read the entire file in memory instead of passing along the IO object. This often leads to out-of-memory errors when the uploaded file is large. We can significantly reduce memory by passing along the unfettered upload IO object. 

Closes #13340