### PR TITLE
fix(core): download with destination as pathname

### DIFF
--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -35,7 +35,10 @@ module Google
           @state = :start
           @download_url = nil
           @offset = 0
-          if download_dest.respond_to?(:write)
+          if @download_dest.is_a?(Pathname)
+            @download_io = File.open(download_dest, 'wb')
+            @close_io_on_finish = true
+          elsif download_dest.respond_to?(:write)
             @download_io = download_dest
             @close_io_on_finish = false
           elsif download_dest.is_a?(String)

--- a/google-apis-core/spec/google/apis/core/download_spec.rb
+++ b/google-apis-core/spec/google/apis/core/download_spec.rb
@@ -135,4 +135,14 @@ RSpec.describe Google::Apis::Core::DownloadCommand do
       end
     end
   end
+
+  context 'with pathname destination' do
+    let(:dest) { Pathname.new(File.join(Dir.mktmpdir, 'test-path.txt')) }
+    let(:received) do
+      command.execute(client)
+      File.read(dest)
+    end
+
+    include_examples 'should download'
+  end
 end


### PR DESCRIPTION
Fixes [#20389](https://github.com/googleapis/google-cloud-ruby/issues/20389)