### PR TITLE
feat(core): Support for universe_domain

### DIFF
--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "retriable", ">= 2.0", "< 4.a"
   gem.add_runtime_dependency "addressable", "~> 2.5", ">= 2.5.1"
   gem.add_runtime_dependency "mini_mime", "~> 1.0"
-  gem.add_runtime_dependency "googleauth", ">= 0.16.2", "< 2.a"
+  gem.add_runtime_dependency "googleauth", "~> 1.9"
   gem.add_runtime_dependency "httpclient", ">= 2.8.1", "< 3.a"
   gem.add_runtime_dependency "rexml"
 end

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Google::Apis::Core::BaseService do
 
   let(:client_version) { "1.2.3" }
   let(:service) { Google::Apis::Core::BaseService.new('https://www.googleapis.com/', '', client_version: client_version) }
+  let(:service_ud) { Google::Apis::Core::BaseService.new('https://www.$UNIVERSE_DOMAIN$/', '', client_version: client_version) }
   let(:service_with_base_path) { Google::Apis::Core::BaseService.new('https://www.googleapis.com/', 'my_service/v1/', client_version: client_version) }
   let(:x_goog_api_client_value) { "gl-ruby/#{RUBY_VERSION} gdcl/#{client_version}" }
 
@@ -476,5 +477,58 @@ EOF
         expect(count).to eq 6
       end
     end
+  end
+
+  it "should default to the global universe domain" do
+    expect(service_ud.universe_domain).to eql "googleapis.com"
+  end
+
+  it "should default to a universe domain from the environment" do
+    ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = "mydomain1.com"
+    expect(service_ud.universe_domain).to eql "mydomain1.com"
+  ensure
+    ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = nil
+  end
+
+  it "should support setting universe domain" do
+    service_ud.universe_domain = "mydomain2.com"
+    expect(service_ud.universe_domain).to eql "mydomain2.com"
+  end
+
+  it "should support setting universe domain to nil" do
+    service_ud.universe_domain = "mydomain2.com"
+    service_ud.universe_domain = nil
+    expect(service_ud.universe_domain).to eql "googleapis.com"
+  end
+
+  it "should update root url when universe domain is set" do
+    service_ud.universe_domain = "mydomain3.com"
+    expect(service_ud.root_url).to eql "https://www.mydomain3.com/"
+  end
+
+  it "should initialize root url using the universe domain" do
+    ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = "mydomain4.com"
+    expect(service_ud.root_url).to eql "https://www.mydomain4.com/"
+  ensure
+    ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] = nil
+  end
+
+  it "should initialize root url with a static value" do
+    expect(service.root_url).to eql "https://www.googleapis.com/"
+  end
+
+  it "should initialize root url with a dynamic value" do
+    expect(service_ud.root_url).to eql "https://www.googleapis.com/"
+  end
+
+  it "should suppport setting root url to a static value" do
+    service_ud.root_url = "https://endpoint1.mydomain5.com/"
+    expect(service_ud.root_url).to eql "https://endpoint1.mydomain5.com/"
+  end
+
+  it "should suppport setting root url to a dynamic value" do
+    service.universe_domain = "mydomain6.com"
+    service.root_url = "https://endpoint2.$UNIVERSE_DOMAIN$/"
+    expect(service.root_url).to eql "https://endpoint2.mydomain6.com/"
   end
 end


### PR DESCRIPTION
Updates to the client base class to support universe domain.

This is the bulk of the change necessary to support universe_domain in these clients. After this is released, the generated code can be updated to pass a template in as the endpoint.

Specifically:

* Require a version of googleauth that supports universe_domain
* Perform substitution if an endpoint with the string `$UNIVERSE_DOMAIN$` is passed in
* Provide an accessor and a constructor argument for universe_domain, and provide the logic to use the environment variable and Google default as default values.
* Repeat endpoint substitution if the universe_domain is modified.

This preserves existing behavior for older clients that set static endpoints (which are now simply treated as endpoint overrides) while implementing full universe_domain support for newer clients that set endpoints with the substitution string.
