### PR TITLE
feat(generator): Support for universe_domain in generated clients

### DIFF
--- a/google-apis-generator/google-apis-generator.gemspec
+++ b/google-apis-generator/google-apis-generator.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
   gem.add_runtime_dependency "activesupport", ">= 5.0"
   gem.add_runtime_dependency "gems", "~> 1.2"
-  gem.add_runtime_dependency "google-apis-core", ">= 0.11.0", "< 2.a"
-  gem.add_runtime_dependency "google-apis-discovery_v1", "~> 0.5"
+  gem.add_runtime_dependency "google-apis-core", ">= 0.12.0", "< 2.a"
+  gem.add_runtime_dependency "google-apis-discovery_v1", "~> 0.14"
   gem.add_runtime_dependency "thor", ">= 0.20", "< 2.a"
 end

--- a/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.required_ruby_version = '>= 2.5'
-  gem.add_runtime_dependency "google-apis-core", ">= 0.11.0", "< 2.a"
+  gem.add_runtime_dependency "google-apis-core", ">= 0.12.0", "< 2.a"
 end

--- a/google-apis-generator/lib/google/apis/generator/templates/service.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/service.rb.tmpl
@@ -34,6 +34,8 @@ module Google
       # @see <%= api.documentation_link %>
 <% end -%>
       class <%= api.service_name %> < Google::Apis::Core::BaseService
+        DEFAULT_ENDPOINT_TEMPLATE = "<%= api.root_url.to_s.sub '.googleapis.com', '.$UNIVERSE_DOMAIN$' %>"
+
 <% for param in api.parameters.values.reject {|p| p.name == 'fields'} -%>
         # @return [<%= param.generated_type %>]
         #  <%= block_comment(param.description, 8, 2) %>
@@ -41,7 +43,7 @@ module Google
 
 <% end -%>
         def initialize
-          super('<%= api.root_url %>', '<%= api.service_path %>',
+          super(DEFAULT_ENDPOINT_TEMPLATE, '<%= api.service_path %>',
                 client_name: '<%= api.gem_name %>',
                 client_version: <%= api.qualified_name %>::GEM_VERSION)
           @batch_path = '<%= api.batch_path %>'


### PR DESCRIPTION
This simply:

* Updates the google-apis-core dependency to a version that supports universe_domain in the base classes
* Passes an endpoint with a universe domain substitution into the base class instead of the google default universe endpoint.

Depends on #17131 being completed and released.