### PR TITLE
fix(core): allow BaseService#root_url to be an Addressable::URI

### DIFF
--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -119,18 +119,21 @@ module Google
         end
 
         # Root URL (host/port) for the API
-        # @return [Addressable::URI]
+        # @return [Addressable::URI, String]
         attr_reader :root_url
 
         # Set the root URL.
         # If the given url includes a universe domain substitution, it is
         # resolved in the current universe domain
         #
-        # @param url_or_template [String] The URL, which can include a universe domain substitution
+        # @param url_or_template [Addressable::URI, String] The URL, which can include a universe domain substitution
         def root_url= url_or_template
-          if url_or_template.include? ENDPOINT_SUBSTITUTION
+          if url_or_template.is_a?(String) && url_or_template.include?(ENDPOINT_SUBSTITUTION)
             @root_url_template = url_or_template
             @root_url = url_or_template.gsub ENDPOINT_SUBSTITUTION, universe_domain
+          elsif url_or_template.is_a?(Addressable::URI) && url_or_template.to_s.include?(ENDPOINT_SUBSTITUTION)
+            @root_url_template = url_or_template.to_s
+            @root_url = Addressable::URI.parse(url_or_template.to_s.gsub(ENDPOINT_SUBSTITUTION, universe_domain))
           else
             @root_url_template = nil
             @root_url = url_or_template

--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -131,9 +131,6 @@ module Google
           if url_or_template.is_a?(String) && url_or_template.include?(ENDPOINT_SUBSTITUTION)
             @root_url_template = url_or_template
             @root_url = url_or_template.gsub ENDPOINT_SUBSTITUTION, universe_domain
-          elsif url_or_template.is_a?(Addressable::URI) && url_or_template.to_s.include?(ENDPOINT_SUBSTITUTION)
-            @root_url_template = url_or_template.to_s
-            @root_url = Addressable::URI.parse(url_or_template.to_s.gsub(ENDPOINT_SUBSTITUTION, universe_domain))
           else
             @root_url_template = nil
             @root_url = url_or_template

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -533,10 +533,21 @@ EOF
     expect(service_ud.root_url).to eql "https://endpoint1.mydomain5.com/"
   end
 
+  it "should support setting root url to Addressable::URI" do
+    service_ud.root_url = Addressable::URI.parse("https://endpoint1.mydomain5.com/")
+    expect(service_ud.root_url).to be_a(Addressable::URI)
+  end
+
   it "should support setting root url to a dynamic value" do
     service.universe_domain = "mydomain6.com"
     service.root_url = "https://endpoint2.$UNIVERSE_DOMAIN$/"
     expect(service.root_url).to eql "https://endpoint2.mydomain6.com/"
+  end
+
+  it "should support setting root url to a dynamic Addressable::URI" do
+    service.universe_domain = "mydomain6.com"
+    service.root_url = Addressable::URI.parse("https://endpoint2.$UNIVERSE_DOMAIN$/")
+    expect(service.root_url).to eql Addressable::URI.parse("https://endpoint2.mydomain6.com/")
   end
 
   describe "#verify_universe_domain!" do

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -544,12 +544,6 @@ EOF
     expect(service.root_url).to eql "https://endpoint2.mydomain6.com/"
   end
 
-  it "should support setting root url to a dynamic Addressable::URI" do
-    service.universe_domain = "mydomain6.com"
-    service.root_url = Addressable::URI.parse("https://endpoint2.$UNIVERSE_DOMAIN$/")
-    expect(service.root_url).to eql Addressable::URI.parse("https://endpoint2.mydomain6.com/")
-  end
-
   describe "#verify_universe_domain!" do
     it "should skip universe domain verification if credentials do not have them" do
       service_ud.authorization = "I have no universe domain"


### PR DESCRIPTION
Follow up to #17131. Addresses #17894.

`BaseService#root_url` is documented as an `Addressable::URI`, but in `BaseService#root_url=` it is used as if it is a `String`. This results in the following error:

```shell
google-apis-core-0.13.0/lib/google/apis/core/base_service.rb:131:in `root_url=': undefined method `include?' for an instance of Addressable::URI (NoMethodError)

          if url_or_template.include? ENDPOINT_SUBSTITUTION
                            ^^^^^^^^^
```

The tests seem to indicate that `root_url` was always allowed to be a `String` and I don't see any code prior to #17131 which required it to be an `Addressable::URI`. Therefore I am proposing updating the documentation to indicate that it can be either.