### PR TITLE
chore: Fix androidpublisher sample

### DIFF
--- a/samples/cli/Gemfile
+++ b/samples/cli/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'google-apis-adsense_v1_4', '~> 0.1'
 gem 'google-apis-analytics_v3', '~> 0.1'
-gem 'google-apis-androidpublisher_v2', '~> 0.1'
+gem 'google-apis-androidpublisher_v3', '~> 0.1'
 gem 'google-apis-bigquery_v2', '~> 0.1'
 gem 'google-apis-calendar_v3', '~> 0.1'
 gem 'google-apis-drive_v3', '~> 0.1'

--- a/samples/cli/lib/samples/androidpublisher.rb
+++ b/samples/cli/lib/samples/androidpublisher.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'google/apis/androidpublisher_v2'
+require 'google/apis/androidpublisher_v3'
 require 'base_cli'
 
 
@@ -23,7 +23,7 @@ module Samples
   #
   #     $ ./google-api-samples androidpublisher upload --apk-path /path/to/com.spiffygame.apk --package-name com.spiffygame
   class Androidpublisher < BaseCli
-    Androidpublisher = Google::Apis::AndroidpublisherV2
+    Androidpublisher = Google::Apis::AndroidpublisherV3
 
     desc 'upload', 'Upload an apk to Google Play'
     method_option :apk_path, type: :string


### PR DESCRIPTION
The gem name is misspelled. See internal issue b/293275155.