### PR TITLE
feat: Update API name definitions for Android Publisher API Subscriptionsv2

### DIFF
--- a/api_names.yaml
+++ b/api_names.yaml
@@ -268,6 +268,8 @@
 "/androidpublisher:v2/androidpublisher.purchases.subscriptions.get": get_purchase_subscription
 "/androidpublisher:v2/androidpublisher.purchases.subscriptions.refund": refund_purchase_subscription
 "/androidpublisher:v2/androidpublisher.purchases.subscriptions.revoke": revoke_purchase_subscription
+"/androidpublisher:v2/androidpublisher.purchases.subscriptionsv2.get": get_purchase_subscription_v2
+"/androidpublisher:v2/androidpublisher.purchases.subscriptionsv2.revoke": revoke_purchase_subscription_v2
 "/autoscaler:v1beta2/AutoscalerListResponse": list_autoscaler_response
 "/bigquery:v2/TableDataInsertAllRequest": insert_all_table_data_request
 "/bigquery:v2/TableDataInsertAllResponse": insert_all_table_data_response


### PR DESCRIPTION
The Ruby client is missing the following REST endpoints.

- https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2/get 
- https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2/revoke

I added the updated `api_names.yml` for the api generator.

I'm not a Google employee so I'm unable to check if this will pass the actions workflows.

The annotations may be weird as the suffix is `v2` and not delimited by a `.`
see Fix singularization of drives #809 for reference.