### PR TITLE
chore: Switch generator pull request management to auto-approve

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,2 @@
+processes:
+  - "RubyApiaryCodegen"

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -12,14 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Install Ruby 3.2
+        uses: actions/checkout@v4
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/weekly-generate-updates.yml
+++ b/.github/workflows/weekly-generate-updates.yml
@@ -9,14 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Install Ruby 3.2
+        uses: actions/checkout@v4
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys


### PR DESCRIPTION
The `YOSHI_APPROVER_TOKEN` is defunct and no longer works. This PR stops attempting to pass it into the generator. Instead, configured the auto-approve bot to handle autoapprove and automerge. Also updated the checkout action and Ruby version for those jobs.

This should not be merged until https://github.com/googleapis/repo-automation-bots/pull/5387 is merged and the auto-approve bot is redeployed.