### PR TITLE
feat(core):  add ECONNRESET error as retriable error

### DIFF
--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -292,7 +292,12 @@ module Google
             rescue Google::Apis::Error => e
               err = e
             end
-          elsif err.is_a?(HTTPClient::TimeoutError) || err.is_a?(SocketError) || err.is_a?(HTTPClient::KeepAliveDisconnected) || err.is_a?(Errno::ECONNREFUSED) || err.is_a?(Errno::ETIMEDOUT)
+          elsif err.is_a?(HTTPClient::TimeoutError) ||
+                err.is_a?(SocketError) ||
+                err.is_a?(HTTPClient::KeepAliveDisconnected) ||
+                err.is_a?(Errno::ECONNREFUSED) ||
+                err.is_a?(Errno::ETIMEDOUT) ||
+                err.is_a?(Errno::ECONNRESET)
             err = Google::Apis::TransmissionError.new(err)
           end
           block.call(nil, err) if block_given?

--- a/google-apis-core/spec/google/apis/core/http_command_spec.rb
+++ b/google-apis-core/spec/google/apis/core/http_command_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe Google::Apis::Core::HttpCommand do
   end
 
   it 'should raise transmission error for broken network connection' do
-    stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_raise(Errno::ETIMEDOUT)
+    stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_raise(Errno::ECONNRESET)
     command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
     command.options.retries = 0
     expect { command.execute(client) }.to raise_error(Google::Apis::TransmissionError)

--- a/google-apis-core/spec/google/apis/core/http_command_spec.rb
+++ b/google-apis-core/spec/google/apis/core/http_command_spec.rb
@@ -495,6 +495,13 @@ RSpec.describe Google::Apis::Core::HttpCommand do
     expect { command.execute(client) }.to raise_error(Google::Apis::TransmissionError)
   end
 
+  it 'should raise transmission error for broken network connection' do
+    stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_raise(Errno::ETIMEDOUT)
+    command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')
+    command.options.retries = 0
+    expect { command.execute(client) }.to raise_error(Google::Apis::TransmissionError)
+  end
+
   it 'should raise rate limit error for 429 status codes' do
     stub_request(:get, 'https://www.googleapis.com/zoo/animals').to_return(status: [429, ''])
     command = Google::Apis::Core::HttpCommand.new(:get, 'https://www.googleapis.com/zoo/animals')


### PR DESCRIPTION
Description: Adding Errno::ECONNRESET to Google::Apis::TransmissionError as retriable error

fixes: https://github.com/googleapis/google-api-ruby-client/issues/18902