### PR TITLE
chore: Keep updating non-preferred gems if they've already been generated

### DIFF
--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -73,10 +73,17 @@ def list_apis_versions
                         path: "discoveries/index.json", update: true)
   apis_versions = []
   JSON.parse(File.read path)["items"].each do |item|
-    next unless item["preferred"]
+    next unless item["preferred"] || gem_exists?(item)
     apis_versions << [item["name"], item["version"]]
   end
   apis_versions.shuffle
+end
+
+def gem_exists? item
+  name = item["name"]
+  version = item["version"]
+  gem_name = "google-apis-#{name}_#{version}"
+  File.file? "#{context_directory}/generated/#{gem_name}/#{gem_name}.gemspec"
 end
 
 def pr_single_gem api, version, index, total


### PR DESCRIPTION
Currently only service versions marked as "preferred" are regenerated. It appears that sometimes as new versions of a service are released, existing old versions are transitioned from "preferred" to "not preferred" status. As a result, the existing clients for those no-longer-preferred versions are no longer updated and grow stale. This PR updates the logic so that existing clients continue to be updated even if they have been moved to "not preferred". (However, a new client is still never created for a "not preferred" version.)

(See #20593)
