### PR TITLE
fix(generator): fix a corner case with a missing ref

### DIFF
--- a/google-apis-generator/lib/google/apis/generator/annotator.rb
+++ b/google-apis-generator/lib/google/apis/generator/annotator.rb
@@ -112,7 +112,7 @@ module Google
           parts = method.id.split('.')
           parts.shift
           verb = ActiveSupport::Inflector.underscore(parts.pop)
-          match = method.request._ref.match(/(.*)(?i:request)/)
+          match = method.request._ref&.match(/(.*)(?i:request)/)
           return nil if match.nil?
           name = ActiveSupport::Inflector.underscore(match[1])
           return nil unless name == verb || name.start_with?(verb + '_')


### PR DESCRIPTION
I think this will fix generation of `google-apis-datalineage_v1` and `google-apis-integrations_v1`.