### PR TITLE
Fix method redefined warning

### DIFF
--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -151,7 +151,7 @@ module Google
 
         # HTTP client
         # @return [HTTPClient]
-        attr_accessor :client
+        attr_writer :client
 
         # General settings
         # @return [Google::Apis::ClientOptions]


### PR DESCRIPTION
```
lib/google/apis/core/base_service.rb:268: warning: method redefined; discarding old client
```

This is because `attr_accessor :client` defines the `client` method, and it's later explicitly redefined.