### PR TITLE
chore: Add Ruby 3.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
             task: "--include-spec"
           - os: ubuntu-latest
             ruby: "3.3"
+            task: "--include-spec"
+          - os: ubuntu-latest
+            ruby: "3.4"
             task: "--include-spec --include-yardoc --include-build"
           - os: macos-latest
-            ruby: "3.3"
+            ruby: "3.4"
             task: "--include-spec"
           - os: windows-latest
-            ruby: "3.3"
+            ruby: "3.4"
             task: "--include-spec"
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pull request adds Ruby 3.4 to CI. 
* Set "--include-spec --include-yardoc --include-build" for the latest Ruby version only.