### PR TITLE
chore: Add 'ostruct' to Gemfile

### DIFF
--- a/google-apis-core/Gemfile
+++ b/google-apis-core/Gemfile
@@ -20,6 +20,7 @@ group :development do
   gem 'opencensus', '~> 0.4'
   gem 'httparty'
   gem 'webrick'
+  gem 'ostruct'
 end
 
 platforms :jruby do


### PR DESCRIPTION
This pull request adds 'ostruct' to Gemfile to suppress `warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.`.

### Steps to reproduce

```ruby
$ ruby -v
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
$ bundle exec rspec -w
```

### Warning fixed by this commit
```ruby
/path/to/google-api-ruby-client/google-apis-core/spec/spec_helper.rb:27: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```