### PR TITLE
chore: Address `warning: literal string will be frozen in the future`

### DIFF
--- a/google-apis-core/lib/google/apis/core/composite_io.rb
+++ b/google-apis-core/lib/google/apis/core/composite_io.rb
@@ -42,7 +42,7 @@ module Google
         end
 
         def read(length = nil, buf = nil)
-          buf = buf ? buf.replace('') : ''
+          buf = buf ? buf.replace('') : ''.dup
 
           begin
             io = @ios[@index]

--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -46,7 +46,7 @@ module Google
             @download_io = File.open(download_dest, 'wb')
             @close_io_on_finish = true
           else
-            @download_io = StringIO.new('', 'wb')
+            @download_io = StringIO.new(''.dup, 'wb')
             @close_io_on_finish = false
           end
           super

--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -283,7 +283,7 @@ module Google
         # @yield [nil, err] if block given
         # @raise [StandardError] if no block
         def error(err, rethrow: false, &block)
-          logger.debug { sprintf('Error - %s', PP.pp(err, '')) }
+          logger.debug { sprintf('Error - %s', PP.pp(err, ''.dup)) }
           if err.is_a?(HTTPClient::BadResponseError)
             begin
               res = err.res
@@ -385,7 +385,7 @@ module Google
         end
 
         def safe_pretty_representation obj
-          out = ""
+          out = "".dup
           printer = RedactingPP.new out, 79
           printer.guard_inspect_key { printer.pp obj }
           printer.flush
@@ -393,7 +393,7 @@ module Google
         end
 
         def safe_single_line_representation obj
-          out = ""
+          out = "".dup
           printer = RedactingSingleLine.new out
           printer.guard_inspect_key { printer.pp obj }
           printer.flush

--- a/google-apis-core/lib/google/apis/core/multipart.rb
+++ b/google-apis-core/lib/google/apis/core/multipart.rb
@@ -31,7 +31,7 @@ module Google
         end
 
         def to_io(boundary)
-          part = ''
+          part = ''.dup
           part << "--#{boundary}\r\n"
           part << "Content-Type: application/json\r\n"
           @header.each do |(k, v)|
@@ -59,7 +59,7 @@ module Google
         end
 
         def to_io(boundary)
-          head = ''
+          head = ''.dup
           head << "--#{boundary}\r\n"
           @header.each do |(k, v)|
             head << "#{k}: #{v}\r\n"

--- a/google-apis-core/lib/google/apis/errors.rb
+++ b/google-apis-core/lib/google/apis/errors.rb
@@ -43,7 +43,7 @@ module Google
       end
 
       def inspect
-        extra = ""
+        extra = "".dup
         extra << " status_code: #{status_code.inspect}" unless status_code.nil?
         extra << " header: #{header.inspect}"           unless header.nil?
         extra << " body: #{body.inspect}"               unless body.nil?


### PR DESCRIPTION
This pull request addresses  `warning: literal string will be frozen in the future` introduced since Ruby 3.4

### Steps to reproduce
This will emit the `warning: literal string will be frozen in the future` warnings and shows the `info: the string was created here` to see where the string literal is created.

```ruby
$ ruby -v
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
$ cd google-apis-core
$ RUBYOPT="--debug-frozen-string-literal" bundle exec rspec -w
```

### Warnings addressed by this commit
```ruby
/path/to/google-apis-core/lib/google/apis/core/composite_io.rb:45: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/download.rb:49: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/http_command.rb:286: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/http_command.rb:388: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/http_command.rb:396: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/multipart.rb:34: info: the string was created here
/path/to/google-apis-core/lib/google/apis/core/multipart.rb:62: info: the string was created here
/path/to/google-apis-core/lib/google/apis/errors.rb:46: info: the string was created here
```
