### PR TITLE
Ensure compatibility with ruby --enable-frozen-string-literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
           - os: windows-latest
             ruby: "3.3"
             task: "--include-spec"
+          - os: ubuntu-latest
+            ruby: "3.4"
+            task: "--include-spec --include-yardoc --include-build"
+            rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -52,6 +56,8 @@ jobs:
         if [ -d /opt/hostedtoolcache/Ruby ]; then
           chmod -R o-w /opt/hostedtoolcache/Ruby
         fi
-    - name: Test ${{ matrix.task }}
+    - name: Test ${{ matrix.task }} ${{ matrix.rubyopt }}
       run: |
         toys ci -v --only ${{ matrix.task }} --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }}
+      env:
+        RUBYOPT: "${{ matrix.rubyopt }}"

--- a/google-apis-core/Gemfile
+++ b/google-apis-core/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'rubocop', '>= 0.49.0', '< 0.93.2'
   gem 'launchy', '~> 2.4'
   gem 'dotenv', '~> 2.0'
-  gem 'fakefs', '>= 1.0', '< 3', require: "fakefs/safe"
+  gem 'fakefs', '>= 1.0', '< 4', require: "fakefs/safe"
   gem 'google-id-token', '~> 1.3'
   gem 'os', '~> 0.9'
   gem 'rmail', '~> 1.1'

--- a/google-apis-core/lib/google/apis/core/composite_io.rb
+++ b/google-apis-core/lib/google/apis/core/composite_io.rb
@@ -42,7 +42,7 @@ module Google
         end
 
         def read(length = nil, buf = nil)
-          buf = buf ? buf.replace('') : ''
+          buf = buf ? buf.replace('') : +''
 
           begin
             io = @ios[@index]

--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -46,7 +46,7 @@ module Google
             @download_io = File.open(download_dest, 'wb')
             @close_io_on_finish = true
           else
-            @download_io = StringIO.new('', 'wb')
+            @download_io = StringIO.new(+'', 'wb')
             @close_io_on_finish = false
           end
           super

--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -283,7 +283,7 @@ module Google
         # @yield [nil, err] if block given
         # @raise [StandardError] if no block
         def error(err, rethrow: false, &block)
-          logger.debug { sprintf('Error - %s', PP.pp(err, '')) }
+          logger.debug { sprintf('Error - %s', PP.pp(err, +'')) }
           if err.is_a?(HTTPClient::BadResponseError)
             begin
               res = err.res
@@ -385,7 +385,7 @@ module Google
         end
 
         def safe_pretty_representation obj
-          out = ""
+          out = +""
           printer = RedactingPP.new out, 79
           printer.guard_inspect_key { printer.pp obj }
           printer.flush
@@ -393,7 +393,7 @@ module Google
         end
 
         def safe_single_line_representation obj
-          out = ""
+          out = +""
           printer = RedactingSingleLine.new out
           printer.guard_inspect_key { printer.pp obj }
           printer.flush

--- a/google-apis-core/lib/google/apis/core/multipart.rb
+++ b/google-apis-core/lib/google/apis/core/multipart.rb
@@ -31,7 +31,7 @@ module Google
         end
 
         def to_io(boundary)
-          part = ''
+          part = +''
           part << "--#{boundary}\r\n"
           part << "Content-Type: application/json\r\n"
           @header.each do |(k, v)|
@@ -59,7 +59,7 @@ module Google
         end
 
         def to_io(boundary)
-          head = ''
+          head = +''
           head << "--#{boundary}\r\n"
           @header.each do |(k, v)|
             head << "#{k}: #{v}\r\n"
@@ -67,7 +67,7 @@ module Google
           head << "Content-Length: #{@length}\r\n" unless @length.nil?
           head << "Content-Transfer-Encoding: binary\r\n"
           head << "\r\n"
-          Google::Apis::Core::CompositeIO.new(StringIO.new(head), @io, StringIO.new("\r\n"))
+          Google::Apis::Core::CompositeIO.new(StringIO.new(head), @io, StringIO.new(+"\r\n"))
         end
       end
 
@@ -126,7 +126,7 @@ module Google
         # @return [IO]
         #  IO stream
         def assemble
-          @parts <<  StringIO.new("--#{@boundary}--\r\n\r\n")
+          @parts <<  StringIO.new(+"--#{@boundary}--\r\n\r\n")
           Google::Apis::Core::CompositeIO.new(*@parts)
         end
       end

--- a/google-apis-core/lib/google/apis/errors.rb
+++ b/google-apis-core/lib/google/apis/errors.rb
@@ -43,7 +43,7 @@ module Google
       end
 
       def inspect
-        extra = ""
+        extra = +""
         extra << " status_code: #{status_code.inspect}" unless status_code.nil?
         extra << " header: #{header.inspect}"           unless header.nil?
         extra << " body: #{body.inspect}"               unless body.nil?

--- a/google-apis-core/spec/google/apis/core/batch_spec.rb
+++ b/google-apis-core/spec/google/apis/core/batch_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Google::Apis::Core::BatchCommand do
 
   let(:post_with_io_command) do
     command = Google::Apis::Core::HttpCommand.new(:post, 'https://www.googleapis.com/zoo/animals/3')
-    command.body = StringIO.new('Goodbye!')
+    command.body = StringIO.new(+'Goodbye!')
     command.header['Content-Type'] = 'text/plain'
     command
   end

--- a/google-apis-core/spec/google/apis/core/composite_io_spec.rb
+++ b/google-apis-core/spec/google/apis/core/composite_io_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Google::Apis::Core::CompositeIO do
   context 'with StringIOs' do
     let(:io) do
       Google::Apis::Core::CompositeIO.new(
-          StringIO.new("Hello "),
-          StringIO.new("Cruel "),
-          StringIO.new("World"))
+          StringIO.new(+"Hello "),
+          StringIO.new(+"Cruel "),
+          StringIO.new(+"World"))
     end
     include_examples 'should act like IO'
   end

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -305,7 +305,7 @@ EOF
       expect do |b|
         service.batch_upload do |service|
           command = service.send(:make_upload_command, :post, 'zoo/animals', {})
-          command.upload_source = StringIO.new('test')
+          command.upload_source = StringIO.new(+'test')
           command.upload_content_type = 'text/plain'
           service.send(:execute_or_queue_command, command, &b)
         end
@@ -316,7 +316,7 @@ EOF
       expect do |b|
         service.batch_upload do |service|
           command = service.send(:make_upload_command, :post, 'zoo/animals', {})
-          command.upload_source = StringIO.new('test')
+          command.upload_source = StringIO.new(+'test')
           command.upload_content_type = 'text/plain'
           expect(command).to be_an_instance_of(Google::Apis::Core::MultipartUploadCommand)
           service.send(:execute_or_queue_command, command, &b)
@@ -328,7 +328,7 @@ EOF
       Google::Apis::RequestOptions.default.authorization = 'a token'
       service.batch_upload do |service|
         command = service.send(:make_upload_command, :post, 'zoo/animals', {})
-        command.upload_source = StringIO.new('test')
+        command.upload_source = StringIO.new(+'test')
         command.upload_content_type = 'text/plain'
         service.send(:execute_or_queue_command, command)
       end

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
   end
 
   context('with StringIO input') do
-    let(:file) { StringIO.new("Hello world") }
+    let(:file) { StringIO.new(+"Hello world") }
     include_examples 'should upload'
     include_examples 'should upload content'
   end
 
   context('with empty StringIO input') do
-    let(:file) { StringIO.new("") }
+    let(:file) { StringIO.new(+"") }
     include_examples 'should upload'
   end
 
@@ -103,7 +103,7 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
   end
 
   context('with files larger than 100 MB') do
-    let(:file) { StringIO.new("Hello world" * 2 )}
+    let(:file) { StringIO.new(+"Hello world" * 2 )}
     before(:example) do
       stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
         .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
@@ -130,7 +130,7 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
   end
 
   context('with chunking disabled') do
-    let!(:file) { StringIO.new("Hello world")}
+    let!(:file) { StringIO.new(+"Hello world")}
     include_examples 'should upload'
 
     it 'should upload content in one request' do

--- a/google-apis-core/spec/google/apis/core/upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/upload_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Google::Apis::Core::RawUploadCommand do
   end
 
   context('with StringIO input') do
-    let(:file) { StringIO.new("Hello world") }
+    let(:file) { StringIO.new(+"Hello world") }
     include_examples 'should upload'
   end
 
@@ -98,7 +98,7 @@ RSpec.describe Google::Apis::Core::MultipartUploadCommand do
 
   let(:command) do
     command = Google::Apis::Core::MultipartUploadCommand.new(:post, 'https://www.googleapis.com/zoo/animals')
-    command.upload_source = StringIO.new('Hello world')
+    command.upload_source = StringIO.new(+'Hello world')
     command.upload_content_type = 'text/plain'
     command.body = 'metadata'
     command
@@ -142,7 +142,7 @@ RSpec.describe Google::Apis::Core::ResumableUploadCommand do
 
   let(:command) do
     command = Google::Apis::Core::ResumableUploadCommand.new(:post, 'https://www.googleapis.com/zoo/animals')
-    command.upload_source = StringIO.new('Hello world')
+    command.upload_source = StringIO.new(+'Hello world')
     command.upload_content_type = 'text/plain'
     command
   end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since Ruby 2.4 it is possible to run ruby with `--enable-frozen-string-literal` and it's supposed to be the default behavior in the future.

It just require some very minor change for this gem to be compatible.