### PR TITLE
chore: Fix CI perms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
     - name: Install tools
       run: |
         gem install --no-document toys
+    - name: Hack perms
+      # Hack permissions to avoid a bundler issue.
+      # See https://github.com/actions/runner-images/issues/10215
+      # and https://github.com/rubygems/rubygems/issues/7983.
+      shell: bash
+      run: |
+        if [ -d /opt/hostedtoolcache/Ruby ]; then
+          chmod -R o-w /opt/hostedtoolcache/Ruby
+        fi
     - name: Test ${{ matrix.task }}
       run: |
         toys ci -v --only ${{ matrix.task }} --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }}


### PR DESCRIPTION
This is a workaround for an issue where we were getting bundler failures during CI, similar to https://github.com/rubygems/rubygems/issues/7983 except that we are on a recent bundler (2.5.22 which ships with Ruby 3.3.7) and are still getting the issue. In our case, it's failing on `syntax_suggest 2.0.1` which unlike most built-in gems, includes an executable that lives in the gem directory so the directory isn't empty.

The workaround for now is to adjust the permissions on the github actions cached gems directory so things aren't world-writable.