### PR TITLE
chore: Updates to release job configs

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -13,15 +13,10 @@ build_file: "google-api-ruby-client/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-release"
 }
 
 env_vars: {
   key: "SECRET_MANAGER_PROJECT_ID"
   value: "cloud-sdk-release-custom-pool"
-}
-
-env_vars: {
-  key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
 }

--- a/.kokoro/release-generated.sh
+++ b/.kokoro/release-generated.sh
@@ -10,11 +10,9 @@ set -eo pipefail
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
-gem install --no-document toys
-toys release install-python-tools -v
-# This is not called from autorelease, so don't run publish-reporter-script
+# This doesn't need to update a pull request, so don't set reporter-org
 if [[ -n "${GEMS_LIST}" ]]; then
-  toys release perform -v --base-dir=generated --gems="${GEMS_LIST}" --enable-docs < /dev/null
+  toys release perform -v --base-dir=generated --gems="${GEMS_LIST}" < /dev/null
 elif [[ -z "${FREEZE_RELEASES}" ]]; then
-  toys release perform -v --base-dir=generated --all=^google-apis- --enable-docs < /dev/null
+  toys release perform -v --base-dir=generated --all=^google-apis- < /dev/null
 fi

--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -5,6 +5,11 @@ env_vars: {
   value: ".kokoro/release.sh"
 }
 
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+}
+
 # Pick up Rubygems key from internal keystore
 before_action {
   fetch_keystore {

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -7,5 +7,4 @@ set -eo pipefail
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
-gem install --no-document toys
 toys release perform -v --reporter-org=googleapis --force-republish < /dev/null


### PR DESCRIPTION
Details:

* Switched release jobs to use the dedicated release image (instead of reusing the CI image)
* No longer load any secret manager keys in the release-generated job since it doesn't need them.
* In the release job, no longer load docuploader_credentials from secret manager since ADC is sufficient.
* No longer install toys from the release scripts since it is present in the release image.
* No longer upload docs to googleapis.dev from generated client releases.
