### PR TITLE
feat(storage):Restart delete resumable upload

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -132,6 +132,7 @@ module Google
                          body: body,
                          header: request_header,
                          follow_redirect: true)
+
           result = process_response(response.status_code, response.header, response.body)
           success(result)
         rescue => e
@@ -171,14 +172,14 @@ module Google
               StringIO.new(upload_io.read(current_chunk_size))
             end
           response = client.put(@upload_url, body: chunk_body, header: request_header, follow_redirect: true)
-
           result = process_response(response.status_code, response.header, response.body)
           @upload_incomplete = false if response.status_code.eql? OK_STATUS
           @offset += current_chunk_size if @upload_incomplete
           success(result)
-        rescue => e
-          upload_io.pos = @offset
-          error(e, rethrow: true)
+          rescue => e
+            upload_io.pos = @offset
+            e.message = e.message + "Please save this upload_url==>#{@upload_url}"
+            error(e, rethrow: true)
         end
 
         # Check the to see if the upload is complete or needs to be resumed.

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -178,7 +178,7 @@ module Google
           success(result)
           rescue => e
             upload_io.pos = @offset
-            e.message = e.message + "Please save this upload_url==>#{@upload_url}"
+            e.message = e.message + ", Please save this upload_url: #{@upload_url}"
             error(e, rethrow: true)
         end
 

--- a/google-apis-core/lib/google/apis/options.rb
+++ b/google-apis-core/lib/google/apis/options.rb
@@ -41,7 +41,9 @@ module Google
       :quota_project,
       :query,
       :add_invocation_id_header,
-      :upload_chunk_size)
+      :upload_chunk_size,
+      :upload_url,
+      :delete_upload)
 
     # General client options
     class ClientOptions

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         )
         .to_return(
           status: [308, 'Resume Incomplete'],
-          headers: { 'Range' => 'bytes=0-21' })
+          headers: { 'Range' => 'bytes=0-21' }
+        )
     end
 
     before(:example) do
@@ -220,7 +221,7 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       expect(a_request(:delete, upload_url)).to have_been_made
     end
 
-    it 'should not call resumable upload when delete upload is called' do
+    it 'should not call resumable upload when upload is cancelled' do
       command.options.upload_chunk_size = 11
       command.options.upload_url = upload_url
       command.execute(client)

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -129,6 +129,106 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
     end
   end
 
+  context('restart resumable upload with upload_url') do
+    let(:file) { StringIO.new('Hello world' * 3) }
+    let(:upload_url) { 'https://www.googleapis.com/zoo/animals' }
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .with(
+          headers: {
+            'Content-Length' => '0',
+            'Content-Range' => 'bytes */33'
+          }
+        )
+        .to_return(
+          status: [308, 'Resume Incomplete'],
+          headers: { 'Range' => 'bytes=0-21' })
+    end
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .with(headers: { 'Content-Range' => 'bytes 22-32/33' })
+        .to_return(body: %(OK))
+    end
+
+    it 'should restart a resumable upload' do
+      command.options.upload_chunk_size = 11
+      command.options.upload_url = upload_url
+      command.execute(client)
+      expect(a_request(:put, upload_url)
+        .with(body: 'Hello world')).to have_been_made
+    end
+  end
+
+  context('should not restart resumable upload if upload is completed') do
+    let(:file) { StringIO.new('Hello world' * 3) }
+    let(:upload_url) { 'https://www.googleapis.com/zoo/animals' }
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .with(
+          headers: {
+            'Content-Length' => '0',
+            'Content-Range' => 'bytes */33'
+          }
+        )
+        .to_return(status: 200, headers: { 'Range' => 'bytes=0-32' })
+    end
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .with(headers: { 'Content-Range' => 'bytes */33' })
+        .to_return(status: 200)
+    end
+
+    it 'should not restart a upload' do
+      command.options.upload_chunk_size = 11
+      command.options.upload_url = upload_url
+      command.execute(client)
+      expect(a_request(:put, upload_url)
+        .with(body: 'Hello world')).to have_not_been_made
+    end
+  end
+
+  context('delete resumable upload with upload_url') do
+    let(:file) { StringIO.new('Hello world' * 3) }
+    let(:upload_url) { 'https://www.googleapis.com/zoo/animals' }
+
+    before(:example) do
+      stub_request(:delete, upload_url)
+        .with(headers: { 'Content-Length' => '0' })
+        .to_return(status: [499])
+    end
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .with(
+          headers: {
+            'Content-Length' => '0',
+            'Content-Range' => 'bytes */33'
+          }
+        )
+        .to_return(status: [499])
+    end
+
+    it 'should cancel a resumable upload' do
+      command.options.upload_chunk_size = 11
+      command.options.upload_url = upload_url
+      command.options.delete_upload = true
+      command.execute(client)
+      expect(a_request(:delete, upload_url)).to have_been_made
+    end
+
+    it 'should not call resumable upload when delete upload is called' do
+      command.options.upload_chunk_size = 11
+      command.options.upload_url = upload_url
+      command.execute(client)
+      expect(a_request(:put, upload_url)
+        .with(body: 'Hello world')).to have_not_been_made
+    end
+  end
+
   context('with chunking disabled') do
     let!(:file) { StringIO.new("Hello world")}
     include_examples 'should upload'


### PR DESCRIPTION
Feature to support Restart and Delete resumable upload functionality
```Ruby
@example   

storage = Google::Cloud::Storage.new upload_chunk_size: chunk_size
#Initiating Resumable upload 
  bucket = storage.bucket bucket_name
 # Restarting  Resumable upload 
  storage = Google::Cloud::Storage.new(upload_chunk_size: chunk_size, upload_url: upload_url)
# Deleting Resumable upload 
  storage = Google::Cloud::Storage.new(upload_chunk_size: chunk_size, upload_url: upload_url, delete_upload: true)

  bucket.create_file file, file_name

```
