### PR TITLE
feat(generator): Generate toys file for each client

### DIFF
--- a/google-apis-generator/lib/google/apis/generator.rb
+++ b/google-apis-generator/lib/google/apis/generator.rb
@@ -79,6 +79,7 @@ module Google
         result.files[result.version_path] = render_template("initial-gem_version.rb", context)
         result.files[File.join(spec_path, "generated_spec.rb")] = render_template("generated_spec.rb", context)
         result.files[File.join(base_path, ".repo-metadata.json")] = render_template("repo-metadata.json", context)
+        result.files[File.join(base_path, ".toys.rb")] = render_template("toys.rb", context)
         result
       end
 

--- a/google-apis-generator/lib/google/apis/generator/templates/toys.rb.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/toys.rb.tmpl
@@ -1,0 +1,57 @@
+expand :clean, paths: :gitignore
+
+expand :rspec do |t|
+  t.libs = ["lib", "spec"]
+  t.use_bundler
+end
+
+expand :yardoc do |t|
+  t.generate_output_flag = true
+  t.use_bundler
+end
+
+expand :gem_build
+
+tool "bundle" do
+  flag :update
+
+  include :exec, e: true
+
+  def run
+    exec ["bundle", update ? "update" : "install"]
+  end
+end
+
+tool "ci" do
+  include :terminal
+  include :exec
+
+  def run
+    Dir.chdir context_directory
+    @gem_name = File.basename context_directory
+    @failures = []
+    step "bundle"
+    step "spec"
+    step "yardoc"
+    step "build"
+    if @failures.empty?
+      puts "CI SUCEEDED", :green, :bold
+    else
+      puts "CI FAILED", :red, :bold
+      @failures.each { |name| puts "  failed: #{name}", :red, :bold }
+      exit 1
+    end
+  end
+
+  def step tool
+    full_name = "#{@gem_name}:#{tool}"
+    puts "Starting: #{full_name}...", :cyan, :bold
+    result = exec_separate_tool [tool]
+    if result.success?
+      puts "SUCCESS: #{full_name}", :green, :bold
+    else
+      @failures << full_name
+      puts "FAILED: #{full_name}", :red, :bold
+    end
+  end
+end


### PR DESCRIPTION
The release process will use `toys build` if present. This is preferred over `bundle exec rake build` because toys doesn't need to install the bundle. This PR updates the generator to generate a toys file; a separate PR will backfill the toys file for existing clients so they won't trigger regeneration and releases.