### PR TITLE
feat!: Replace underlying httpclient library with Faraday

### DIFF
--- a/google-apis-core/OVERVIEW.md
+++ b/google-apis-core/OVERVIEW.md
@@ -4,6 +4,24 @@ This library includes common base classes and dependencies used by legacy REST
 clients for Google APIs. It is used by client libraries, but you should not
 need to install it by itself.
 
+## Usage
+
+In most cases, this library is installed automatically as a dependency of
+another library. For example, if you install the
+[google-apis-drive_v3](https://rubygems.org/gems/google-apis-drive_v3) client
+library, it will bring in the latest `google-apis-core` as a dependency. Thus,
+in most cases, you do not need to add `google-apis-core` to your Gemfile
+directly.
+
+Earlier (0.x) versions of this library utilized the legacy
+[httpclient](https://rubygems.org/gems/httpclient) gem and made some of its
+interfaces available for advanced use cases. Version 1.0 and later of this
+library replaced httpclient with [faraday](https://rubygems.org/gems/faraday).
+If your application makes use of the httpclient interfaces (this is rare), you
+should pin `google-apis-core` to a 0.x version in your Gemfile. For example:
+
+    gem "google-apis-core", "~> 0.18"
+
 ## Documentation
 
 More detailed descriptions of the Google legacy REST clients are available in two documents.

--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.1'
   gem.add_runtime_dependency "representable", "~> 3.0"
-  gem.add_runtime_dependency "retriable", ">= 2.0", "< 4.a"
-  gem.add_runtime_dependency "addressable", "~> 2.5", ">= 2.5.1"
-  gem.add_runtime_dependency "mini_mime", "~> 1.0"
-  gem.add_runtime_dependency "googleauth", "~> 1.9"
-  gem.add_runtime_dependency "httpclient", ">= 2.8.3", "< 3.a"
-  gem.add_runtime_dependency "mutex_m" # used by httpclient
+  gem.add_runtime_dependency "retriable", "~> 3.1"
+  gem.add_runtime_dependency "addressable", "~> 2.8", ">= 2.8.7"
+  gem.add_runtime_dependency "mini_mime", "~> 1.1"
+  gem.add_runtime_dependency "googleauth", "~> 1.14"
+  gem.add_runtime_dependency "faraday", "~> 2.13"
+  gem.add_runtime_dependency "faraday-follow_redirects", "~> 0.3"
 end

--- a/google-apis-core/lib/google/apis/core/batch.rb
+++ b/google-apis-core/lib/google/apis/core/batch.rb
@@ -211,12 +211,12 @@ module Google
 
         protected
 
-        # Auxiliary method to split the header from the body in an HTTP response.
+        # Auxiliary method to split the headers from the body in an HTTP response.
         #
         # @param [String] response
         #   the response to parse.
-        # @return [Array<(Hash, String)>]
-        #   the header and the body, separately.
+        # @return [Array<(Hash{String=>Array<String>}, String)>]
+        #   the headers and the body, separately.
         def split_header_and_body(response)
           headers = {}
           payload = response.lstrip

--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -23,6 +23,8 @@ module Google
       # Streaming/resumable media download support
       class DownloadCommand < ApiCommand
         RANGE_HEADER = 'Range'
+
+        # @deprecated No longer used
         OK_STATUS = [200, 201, 206]
 
         # File or IO to write content to
@@ -82,6 +84,7 @@ module Google
               status = res.status.to_i
               next if chunk.nil? || (status >= 300 && status < 400)
 
+              # HTTP 206 is Partial Content
               download_offset ||= (status == 206 ? @offset : 0)
               download_offset  += chunk.bytesize
 

--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -61,8 +61,7 @@ module Google
         # of file content.
         #
         # @private
-        # @param [HTTPClient] client
-        #   HTTP client
+        # @param [Faraday::Connection] client Faraday connection
         # @yield [result, err] Result or error if block supplied
         # @return [Object]
         # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
@@ -78,39 +77,38 @@ module Google
             request_header[RANGE_HEADER] = sprintf('bytes=%d-', @offset)
           end
 
-          http_res = client.get(url.to_s,
-                     query: query,
-                     header: request_header,
-                     follow_redirect: true) do |res, chunk|
-            status = res.http_header.status_code.to_i
-            next unless OK_STATUS.include?(status)
+          http_res = client.get(url.to_s, query, request_header) do |request|
+            request.options.on_data = proc do |chunk, _size, res|
+              status = res.status.to_i
+              next if chunk.nil? || (status >= 300 && status < 400)
 
-            download_offset ||= (status == 206 ? @offset : 0)
-            download_offset  += chunk.bytesize
+              download_offset ||= (status == 206 ? @offset : 0)
+              download_offset  += chunk.bytesize
 
-            if download_offset - chunk.bytesize == @offset
-              next_chunk = chunk
-            else
-              # Oh no! Requested a chunk, but received the entire content
-              chunk_index = @offset - (download_offset - chunk.bytesize)
-              next_chunk = chunk.byteslice(chunk_index..-1)
-              next if next_chunk.nil?
+              if download_offset - chunk.bytesize == @offset
+                next_chunk = chunk
+              else
+                # Oh no! Requested a chunk, but received the entire content
+                chunk_index = @offset - (download_offset - chunk.bytesize)
+                next_chunk = chunk.byteslice(chunk_index..-1)
+                next if next_chunk.nil?
+              end
+
+              # logger.debug { sprintf('Writing chunk (%d bytes, %d total)', chunk.length, bytes_read) }
+              @download_io.write(next_chunk)
+
+              @offset += next_chunk.bytesize
             end
-
-            # logger.debug { sprintf('Writing chunk (%d bytes, %d total)', chunk.length, bytes_read) }
-            @download_io.write(next_chunk)
-
-            @offset += next_chunk.bytesize
           end
 
-         @download_io.flush if @download_io.respond_to?(:flush)
+          @download_io.flush if @download_io.respond_to?(:flush)
 
           if @close_io_on_finish
             result = nil
           else
             result = @download_io
           end
-          check_status(http_res.status.to_i, http_res.header, http_res.body)
+          check_status(http_res.status.to_i, http_res.headers, http_res.body)
           success(result, &block)
         rescue => e
           @download_io.flush if @download_io.respond_to?(:flush)

--- a/google-apis-core/lib/google/apis/core/faraday_integration.rb
+++ b/google-apis-core/lib/google/apis/core/faraday_integration.rb
@@ -28,20 +28,20 @@ module Google
       end
 
       Faraday::Response.register_middleware(follow_redirects_google_apis_core: FollowRedirectsMiddleware)
-    end
-  end
-end
 
-module Faraday
-  class Response
-    # Compatibility alias.
-    # Earlier versions based on the old `httpclient` gem used `HTTP::Message`,
-    # which defined the `header` field that some clients, notably
-    # google-cloud-storage, depend on.
-    # Faraday's `headers` isn't an exact replacement because its values are
-    # single strings whereas `HTTP::Message` values are arrays, but
-    # google-cloud-storage already passes the result through `Array()` so this
-    # should work sufficiently.
-    alias header headers
+      # Customized subclass of Faraday::Response with additional capabilities
+      # needed by older versions of some downstream dependencies.
+      class Response < Faraday::Response
+        # Compatibility alias.
+        # Earlier versions based on the old `httpclient` gem used `HTTP::Message`,
+        # which defined the `header` field that some clients, notably
+        # google-cloud-storage, depend on.
+        # Faraday's `headers` isn't an exact replacement because its values are
+        # single strings whereas `HTTP::Message` values are arrays, but
+        # google-cloud-storage already passes the result through `Array()` so this
+        # should work sufficiently.
+        alias header headers
+      end
+    end
   end
 end

--- a/google-apis-core/lib/google/apis/core/faraday_integration.rb
+++ b/google-apis-core/lib/google/apis/core/faraday_integration.rb
@@ -1,0 +1,47 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "faraday"
+require "faraday/follow_redirects"
+
+module Google
+  module Apis
+    module Core
+      # Customized version of the FollowRedirects middleware that does not
+      # trigger on 308. HttpCommand wants to handle 308 itself for resumable
+      # uploads.
+      class FollowRedirectsMiddleware < Faraday::FollowRedirects::Middleware
+        def follow_redirect?(env, response)
+          super && response.status != 308
+        end
+      end
+
+      Faraday::Response.register_middleware(follow_redirects_google_apis_core: FollowRedirectsMiddleware)
+    end
+  end
+end
+
+module Faraday
+  class Response
+    # Compatibility alias.
+    # Earlier versions based on the old `httpclient` gem used `HTTP::Message`,
+    # which defined the `header` field that some clients, notably
+    # google-cloud-storage, depend on.
+    # Faraday's `headers` isn't an exact replacement because its values are
+    # single strings whereas `HTTP::Message` values are arrays, but
+    # google-cloud-storage already passes the result through `Array()` so this
+    # should work sufficiently.
+    alias header headers
+  end
+end

--- a/google-apis-core/lib/google/apis/core/storage_download.rb
+++ b/google-apis-core/lib/google/apis/core/storage_download.rb
@@ -30,8 +30,7 @@ module Google
         # here too.
         #
         # @private
-        # @param [HTTPClient] client
-        #   HTTP client
+        # @param [Faraday::Connection] client Faraday connection
         # @yield [result, err] Result or error if block supplied
         # @return [Object]
         # @raise [Google::Apis::ServerError] An error occurred on the server and the request can be retried
@@ -47,39 +46,38 @@ module Google
             request_header[RANGE_HEADER] = sprintf('bytes=%d-', @offset)
           end
 
-          http_res = client.get(url.to_s,
-                     query: query,
-                     header: request_header,
-                     follow_redirect: true) do |res, chunk|
-            status = res.http_header.status_code.to_i
-            next unless OK_STATUS.include?(status)
+          http_res = client.get(url.to_s, query, request_header) do |request|
+            request.options.on_data = proc do |chunk, _size, res|
+              status = res.status.to_i
+              next if chunk.nil? || (status >= 300 && status < 400)
 
-            download_offset ||= (status == 206 ? @offset : 0)
-            download_offset  += chunk.bytesize
+              download_offset ||= (status == 206 ? @offset : 0)
+              download_offset  += chunk.bytesize
 
-            if download_offset - chunk.bytesize == @offset
-              next_chunk = chunk
-            else
-              # Oh no! Requested a chunk, but received the entire content
-              chunk_index = @offset - (download_offset - chunk.bytesize)
-              next_chunk = chunk.byteslice(chunk_index..-1)
-              next if next_chunk.nil?
+              if download_offset - chunk.bytesize == @offset
+                next_chunk = chunk
+              else
+                # Oh no! Requested a chunk, but received the entire content
+                chunk_index = @offset - (download_offset - chunk.bytesize)
+                next_chunk = chunk.byteslice(chunk_index..-1)
+                next if next_chunk.nil?
+              end
+
+              # logger.debug { sprintf('Writing chunk (%d bytes, %d total)', chunk.length, bytes_read) }
+              @download_io.write(next_chunk)
+
+              @offset += next_chunk.bytesize
             end
-
-            # logger.debug { sprintf('Writing chunk (%d bytes, %d total)', chunk.length, bytes_read) }
-            @download_io.write(next_chunk)
-
-            @offset += next_chunk.bytesize
           end
 
-         @download_io.flush if @download_io.respond_to?(:flush)
+          @download_io.flush if @download_io.respond_to?(:flush)
 
           if @close_io_on_finish
             result = nil
           else
             result = @download_io
           end
-          check_status(http_res.status.to_i, http_res.header, http_res.body)
+          check_status(http_res.status.to_i, http_res.headers, http_res.body)
           # In case of file download in storage, we need to respond back with http 
           # header along with the actual object.
           success([result, http_res], &block)

--- a/google-apis-core/lib/google/apis/core/storage_download.rb
+++ b/google-apis-core/lib/google/apis/core/storage_download.rb
@@ -78,8 +78,13 @@ module Google
             result = @download_io
           end
           check_status(http_res.status.to_i, http_res.headers, http_res.body)
-          # In case of file download in storage, we need to respond back with http 
-          # header along with the actual object.
+          # In case of file download in storage, we need to respond back with
+          # the http response object along with the result IO object, because
+          # google-cloud-storage uses the HTTP info.
+          # Also, older versions of google-cloud-storage assume this object
+          # conforms to the old httpclient response API instead of the Faraday
+          # response API. Return a subclass that provides the needed methods.
+          http_res = Core::Response.new http_res.env
           success([result, http_res], &block)
         rescue => e
           @download_io.flush if @download_io.respond_to?(:flush)

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -239,7 +239,7 @@ module Google
             @close_io_on_finish = true
             true # method returns true if upload is successfully cancelled
           else
-            logger.debug { sprintf("Failed to cancel upload session. Response: #{response.status} - #{response.body}") }
+            logger.debug { sprintf("Failed to cancel upload session. Response: #{response.status.to_i} - #{response.body}") }
           end
   
         end
@@ -264,7 +264,7 @@ module Google
             # Upload is complete.
             @upload_incomplete = false
           else
-            logger.debug { sprintf("Unexpected response: #{response.status} - #{response.body}") }
+            logger.debug { sprintf("Unexpected response: #{response.status.to_i} - #{response.body}") }
             @upload_incomplete = true
           end
         end

--- a/google-apis-core/lib/google/apis/options.rb
+++ b/google-apis-core/lib/google/apis/options.rb
@@ -61,7 +61,7 @@ module Google
       # @!attribute [rw] read_timeout_sec
       #   @return [Integer] How long, in seconds, before receiving data times out
       # @!attribute [rw] transparent_gzip_decompression
-      # @return [Boolean] True if gzip compression needs to be enabled
+      #   @return [Boolean] DEPRECATED. Gzip decompression is now always on.
       # Get the default options
       # @return [Google::Apis::ClientOptions]
       def self.default

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
 
     it 'should send upload command' do
       allow(client).to receive(:put).and_call_original
-      expect(client).to receive(:put).with(anything, hash_including(body: kind_of(StringIO)))
+      expect(client).to receive(:put).with(anything, kind_of(StringIO), kind_of(Hash))
 
       command.execute(client)
       expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')).to have_been_made


### PR DESCRIPTION
This is a often-requested step due to httpclient being largely unmaintained. We've been putting it off for a long time because it induces breaking changes for any downstream dependents (such as the Google Cloud Storage client) that rely on httpclient types. However, we're now in a situation where Google Cloud Storage client feature roadmap requires HTTP capabilities not available in httpclient. So we're going to bite the bullet and do this change.

This pull request rips out httpclient and replaces it with faraday and faraday-follow_redirects, updating usage accordingly. A few public interfaces that previously exposed httpclient types now expose equivalent Faraday types, which is technically a breaking change. We will therefore release this as a semver-major (v1.0) release. Customers who depend on the httpclient types can pin the google-apis-core gem to v0.x. Note that the current direct dependents (the generated apiary clients) already declare dependencies as `< 2.a` so will work with either the older 0.x or newer 1.x cores.

Note: the google-cloud-storage gem is a primary dependent, and it has code that depends on an exposed httpclient object. We have therefore included in this gem a minimal patch to Faraday to provide just the interface needed by google-cloud-storage, so that it will work against both v0.x and v1.x releases.

This change has been verified against the integration tests for two major dependents: google-cloud-storage and google-cloud-bigquery.

Closes #2348
Closes #21381