### PR TITLE
revert: setting idempotency header (#22517)

### DIFF
--- a/google-apis-core/lib/google/apis/core/api_command.rb
+++ b/google-apis-core/lib/google/apis/core/api_command.rb
@@ -18,6 +18,7 @@ require 'google/apis/core/http_command'
 require 'google/apis/errors'
 require 'json'
 require 'retriable'
+require "securerandom"
 
 module Google
   module Apis
@@ -69,7 +70,6 @@ module Google
         def prepare!
           set_api_client_header
           set_user_project_header
-          set_idempotency_token_header 
           if options&.api_format_version
             header['X-Goog-Api-Format-Version'] = options.api_format_version.to_s
           end
@@ -143,7 +143,6 @@ module Google
         end
 
         private
-        INVOCATION_ID = SecureRandom.uuid
 
         def set_api_client_header
           old_xgac = header
@@ -175,12 +174,8 @@ module Google
           header['X-Goog-User-Project'] = quota_project_id if quota_project_id
         end
 
-        def set_idempotency_token_header
-          header['X-Goog-Gcs-Idempotency-Token'] = INVOCATION_ID
-        end
-
         def invocation_id_header
-          "gccl-invocation-id/#{INVOCATION_ID}"
+          "gccl-invocation-id/#{SecureRandom.uuid}"
         end
 
         # Attempt to parse a JSON error message

--- a/google-apis-core/spec/google/apis/core/api_command_spec.rb
+++ b/google-apis-core/spec/google/apis/core/api_command_spec.rb
@@ -34,14 +34,10 @@ RSpec.describe Google::Apis::Core::ApiCommand do
 
   let(:client_version) { "1.2.3" }
   let(:x_goog_api_client_value) { "gl-ruby/#{RUBY_VERSION} gdcl/#{client_version}" }
+
   context('with preparation') do
     let(:command) do
       Google::Apis::Core::ApiCommand.new(:get, 'https://www.googleapis.com/zoo/animals', client_version: client_version)
-    end
-    let(:invocation_id) { 'test123' }
-
-    before(:example) do
-      Google::Apis::Core::ApiCommand.const_set(:INVOCATION_ID, invocation_id)
     end
 
     it 'should set X-Goog-Api-Client header if none is set' do
@@ -93,14 +89,6 @@ RSpec.describe Google::Apis::Core::ApiCommand do
       command.options.add_invocation_id_header = true
       command.prepare!
       expect(command.header["X-Goog-Api-Client"]).to include("gccl-invocation-id")
-      expect(command.header["X-Goog-Api-Client"]).to include(invocation_id)
-
-    end
-
-    it "should set the X-Goog-Gcs-Idempotency-Token header" do
-      command.prepare!
-      expect(command.header['X-Goog-Gcs-Idempotency-Token']).not_to be_nil
-      expect(command.header['X-Goog-Gcs-Idempotency-Token']).to eql invocation_id
     end
   end
 
@@ -262,17 +250,10 @@ EOF
       command.options.add_invocation_id_header = true
       result = command.execute(client)
       invocation_id_header = command.header["X-Goog-Api-Client"]
+      
       expect(invocation_id_header).to include("gccl-invocation-id")
       expect(a_request(:get, 'https://www.googleapis.com/zoo/animals')
         .with { |req| req.headers['X-Goog-Api-Client'] == invocation_id_header }).to have_been_made.times(2)
-    end
-
-    it 'should keep same idempotency_token across retries' do
-      result = command.execute(client)
-      idempotency_token_header = command.header['X-Goog-Gcs-Idempotency-Token']
-      expect(a_request(:get, 'https://www.googleapis.com/zoo/animals')
-        .with { |req| req.headers['X-Goog-Gcs-Idempotency-Token'] == idempotency_token_header })
-        .to have_been_made.times(2)
     end
   end
 

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Google::Apis::Core::BaseService do
   let(:service_ud) { Google::Apis::Core::BaseService.new('https://www.$UNIVERSE_DOMAIN$/', '', client_version: client_version) }
   let(:service_with_base_path) { Google::Apis::Core::BaseService.new('https://www.googleapis.com/', 'my_service/v1/', client_version: client_version) }
   let(:x_goog_api_client_value) { "gl-ruby/#{RUBY_VERSION} gdcl/#{client_version}" }
-  let(:invocation_id) { 'test123' }
 
   before do
     Google::Apis::ClientOptions.default.application_name = 'test'
@@ -375,7 +374,6 @@ EOF
 
   context 'with batch uploads' do
     before(:example) do
-      Google::Apis::Core::ApiCommand.const_set(:INVOCATION_ID, invocation_id)
       allow(SecureRandom).to receive(:uuid).and_return('b1981e17-f622-49af-b2eb-203308b1b17d')
       allow(Digest::SHA1).to receive(:hexdigest).and_return('outer', 'inner')
       response = <<EOF.gsub(/\n/, "\r\n")
@@ -432,7 +430,6 @@ Content-Transfer-Encoding: binary
 
 POST /upload/zoo/animals\\? HTTP/1\\.1
 X-Goog-Api-Client: #{Regexp.escape(x_goog_api_client_value)}
-X-Goog-Gcs-Idempotency-Token: #{invocation_id}
 Content-Type: multipart/related; boundary=inner
 X-Goog-Upload-Protocol: multipart
 Authorization: Bearer a token


### PR DESCRIPTION
This reverts commit 0f5a074e55388a3b22db774d6701c736b514347c (pull request #22517).

There are several issues with the original pull request, notably that it sets the invocation ID as a constant, meaning ALL calls from the same Ruby VM will always use the same invocation ID. This will likely confuse any consumer of this value. (Indeed, some basic integration tests run against that code yielded weird results.)

Fortunately, the original commit used an incorrect conventional commit tag, and so did not trigger a release.