### PR TITLE
fix(core): Compute and send content-length header when posting a CompositeIO

### DIFF
--- a/google-apis-core/lib/google/apis/core/http_command.rb
+++ b/google-apis-core/lib/google/apis/core/http_command.rb
@@ -183,6 +183,9 @@ module Google
           end
 
           self.body = '' if self.body.nil? && [:post, :put, :patch].include?(method)
+          if defined?(::Google::Apis::Core::CompositeIO) && body.is_a?(::Google::Apis::Core::CompositeIO)
+            header["Content-Length"] ||= body.size.to_s
+          end
         end
 
         # Release any resources used by this command

--- a/google-apis-core/spec/google/apis/core/batch_spec.rb
+++ b/google-apis-core/spec/google/apis/core/batch_spec.rb
@@ -118,7 +118,10 @@ Goodbye!
 --123abc--
 
 EOF
-    expect(a_request(:post, 'https://www.googleapis.com/batch').with(body: expected_body)).to have_been_made
+    expect(
+      a_request(:post, 'https://www.googleapis.com/batch')
+        .with(body: expected_body, headers: {"Content-Length" => expected_body.size.to_s})
+    ).to have_been_made
   end
 
   it 'should send content with authorization header when set' do


### PR DESCRIPTION
Fixes #23863 