### PR TITLE
chore: Error handling when upload id I'd incorrect for Resumable upload

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -239,12 +239,16 @@ module Google
           response = client.delete(@upload_url, nil, request_header)
           handle_resumable_upload_http_response_codes(response)
 
-          if !@upload_incomplete && (400..499).include?(response.status.to_i) && response.status.to_i != 404
+          is_successful_cancellation =
+            !@upload_incomplete &&
+            (400..499).cover?(response.status.to_i) &&
+            response.status.to_i != 404
+          if is_successful_cancellation
             @close_io_on_finish = true
-            true # method returns true if upload is successfully cancelled
+            return true # method returns true if upload is successfully cancelled
           else
-            logger.debug { sprintf("Failed to cancel upload session. Response: #{response.status.to_i} - #{response.body}") }
-            false
+            logger.debug { "Failed to cancel upload session. Response: #{response.status.to_i} - #{response.body}" }
+            return false
           end
         end
 

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -149,9 +149,7 @@ module Google
         # Reinitiating resumable upload
         def reinitiate_resumable_upload(client)
           logger.debug { sprintf('Restarting resumable upload command to %s', url) }
-          unless check_resumable_upload client
-            return false
-          end
+          return false unless check_resumable_upload client
           upload_io.pos = @offset
         end
 
@@ -248,7 +246,6 @@ module Google
             logger.debug { sprintf("Failed to cancel upload session. Response: #{response.status.to_i} - #{response.body}") }
             false
           end
-  
         end
 
         def handle_resumable_upload_http_response_codes(response)

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -225,7 +225,7 @@ module Google
           response = client.put(@upload_url, "", request_header)
           handle_resumable_upload_http_response_codes(response)
           if response.status.to_i == 404
-            logger.debug { sprintf("Failed to fetch upload session. Response: #{response.status.to_i} - #{response.body}") }
+            logger.debug { "Failed to fetch upload session. Response: #{response.status.to_i} - #{response.body}" }
             false
           end
         end

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Google::Apis::Core::BaseService do
           .to_return(status: 404)
       end
       it 'should return false' do
-        expect(command).to be_falsey
+        expect(command).to be(false)
       end
     end
 
@@ -345,7 +345,7 @@ RSpec.describe Google::Apis::Core::BaseService do
           .to_return(status: 404)
       end
       it 'should return false' do
-        expect(command).to be_falsey
+        expect(command).to be(false)
       end
     end
   end

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -287,6 +287,24 @@ RSpec.describe Google::Apis::Core::BaseService do
         expect(a_request(:put, upload_url)).to have_been_made
       end
     end
+    context 'Should return false if wrong upload id is provided' do
+      let(:upload_id) { 'wrong_id' }
+      let(:command) do
+        service.send(
+          :restart_resumable_upload,
+          bucket_name, file, upload_id,
+          options: { upload_chunk_size: 11}
+        )
+      end
+      before(:example) do
+        stub_request(:put, upload_url)
+          .to_return(status: 404)
+      end
+      it 'should return false' do
+        expect(command).to be_falsey
+      end
+    end
+
   end
 
   context 'delete resumable upload with upload_id' do
@@ -311,6 +329,24 @@ RSpec.describe Google::Apis::Core::BaseService do
       command
       expect(a_request(:delete, upload_url)).to have_been_made
       expect(command).to be_truthy
+    end
+
+    context 'Should return false if wrong upload id is provided' do
+      let(:upload_id) { 'wrong_id' }
+      let(:command) do
+      service.send(
+        :delete_resumable_upload,
+        bucket_name, upload_id,
+        options: { upload_chunk_size: 11}
+      )
+    end
+      before(:example) do
+        stub_request(:delete, upload_url)
+          .to_return(status: 404)
+      end
+      it 'should return false' do
+        expect(command).to be_falsey
+      end
     end
   end
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -161,6 +161,14 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       expect(a_request(:put, upload_url)
         .with(body: 'Hello world')).to have_been_made
     end
+
+    it 'should return false if wrong upload id is provided' do
+      stub_request(:put, upload_url)
+        .to_return(status: 404)
+      command.options.upload_chunk_size = 11
+      command.upload_id = "wrong_upload_id"
+      expect(command.execute(client)).to be_falsy
+    end
   end
 
   context('should not restart resumable upload if upload is completed') do
@@ -234,6 +242,15 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       command.execute(client)
       expect(a_request(:put, upload_url)
         .with(body: 'Hello world')).to have_not_been_made
+    end
+
+    it 'should return false if wrong upload id is provided' do
+      stub_request(:delete, upload_url)
+        .to_return(status: 404)
+      command.options.upload_chunk_size = 11
+      command.upload_id = "wrong_upload_id"
+      command.delete_upload = true
+      expect(command.execute(client)).to be_falsy
     end
   end
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 require 'google/apis/core/storage_upload'
 require 'google/apis/core/json_representation'
-require 'pry'
+
 RSpec.describe Google::Apis::Core::StorageUploadCommand do
   include TestHelpers
   include_context 'HTTP client'

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 require 'google/apis/core/storage_upload'
 require 'google/apis/core/json_representation'
-
+require 'pry'
 RSpec.describe Google::Apis::Core::StorageUploadCommand do
   include TestHelpers
   include_context 'HTTP client'
@@ -162,11 +162,23 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         .with(body: 'Hello world')).to have_been_made
     end
 
+  end
+
+  context('restart resumable upload with wrong upload_id') do
+    let(:file) { StringIO.new('Hello world' * 3) }
+    let(:upload_id) { 'wrong_upload_id' }
+    let(:upload_url) { "https://www.googleapis.com/zoo/animals?uploadType=resumable&upload_id=#{upload_id}" }
+
+    before(:example) do
+      stub_request(:put, upload_url)
+        .to_return(status: 404)
+    end
+
     it 'should return false if wrong upload id is provided' do
       stub_request(:put, upload_url)
         .to_return(status: 404)
       command.options.upload_chunk_size = 11
-      command.upload_id = "wrong_upload_id"
+      command.upload_id = upload_id
       expect(command.execute(client)).to be_falsy
     end
   end
@@ -244,11 +256,21 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         .with(body: 'Hello world')).to have_not_been_made
     end
 
-    it 'should return false if wrong upload id is provided' do
+  end
+
+  context('delete resumable upload with upload_id') do
+    let(:file) { StringIO.new('Hello world' * 3) }
+    let(:upload_id) { 'wrong_upload_id' }
+    let(:upload_url) { "https://www.googleapis.com/zoo/animals?uploadType=resumable&upload_id=#{upload_id}" }
+
+    before(:example) do
       stub_request(:delete, upload_url)
         .to_return(status: 404)
+    end
+
+    it 'should return false if wrong upload id is provided' do
       command.options.upload_chunk_size = 11
-      command.upload_id = "wrong_upload_id"
+      command.upload_id = upload_id
       command.delete_upload = true
       expect(command.execute(client)).to be_falsy
     end


### PR DESCRIPTION
Updated code to  explicitly handle 404 (Not Found) responses, ensuring that operations correctly fail when an upload session ID is  invalid.

Error handling done for code implemented in  - https://github.com/googleapis/google-api-ruby-client/pull/21896, https://github.com/googleapis/google-api-ruby-client/pull/23376

Implementation linked with- https://github.com/googleapis/google-cloud-ruby/pull/30882