### PR TITLE
fix(core): Handle nil response in on_data callback for Faraday streaming

### DIFF
--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -81,6 +81,9 @@ module Google
 
           http_res = client.get(url.to_s, query, request_header) do |request|
             request.options.on_data = proc do |chunk, _size, res|
+              # The on_data callback is only invoked on a successful response.
+              # Some Faraday adapters (e.g. Typhoeus) may not provide a response
+              # object in the callback, so we default to a 200 OK status.
               status = res ? res.status.to_i : 200
               next if chunk.nil? || (status >= 300 && status < 400)
 

--- a/google-apis-core/lib/google/apis/core/download.rb
+++ b/google-apis-core/lib/google/apis/core/download.rb
@@ -81,7 +81,7 @@ module Google
 
           http_res = client.get(url.to_s, query, request_header) do |request|
             request.options.on_data = proc do |chunk, _size, res|
-              status = res.status.to_i
+              status = res ? res.status.to_i : 200
               next if chunk.nil? || (status >= 300 && status < 400)
 
               # HTTP 206 is Partial Content

--- a/google-apis-core/lib/google/apis/core/storage_download.rb
+++ b/google-apis-core/lib/google/apis/core/storage_download.rb
@@ -48,7 +48,7 @@ module Google
 
           http_res = client.get(url.to_s, query, request_header) do |request|
             request.options.on_data = proc do |chunk, _size, res|
-              status = res.status.to_i
+              status = res ? res.status.to_i : 200
               next if chunk.nil? || (status >= 300 && status < 400)
 
               download_offset ||= (status == 206 ? @offset : 0)

--- a/google-apis-core/lib/google/apis/core/storage_download.rb
+++ b/google-apis-core/lib/google/apis/core/storage_download.rb
@@ -48,6 +48,9 @@ module Google
 
           http_res = client.get(url.to_s, query, request_header) do |request|
             request.options.on_data = proc do |chunk, _size, res|
+              # The on_data callback is only invoked on a successful response.
+              # Some Faraday adapters (e.g. Typhoeus) may not provide a response
+              # object in the callback, so we default to a 200 OK status.
               status = res ? res.status.to_i : 200
               next if chunk.nil? || (status >= 300 && status < 400)
 

--- a/google-apis-core/spec/google/apis/core/download_spec.rb
+++ b/google-apis-core/spec/google/apis/core/download_spec.rb
@@ -136,6 +136,27 @@ RSpec.describe Google::Apis::Core::DownloadCommand do
     end
   end
 
+  context 'with streaming response' do
+    let(:dest) { Tempfile.new('test') }
+    let(:received) do
+      command.execute(client)
+      dest.rewind
+      dest.read
+    end
+
+    it 'should receive content' do
+      response = Faraday::Response.new(status: 200, body: 'Hello world')
+      expect(client).to receive(:get) do |_url, _params, _headers, &block|
+        request = Faraday::Request.new
+        request.options = Faraday::RequestOptions.new
+        block.call(request)
+        request.options.on_data.call('Hello world', 11, nil)
+        response
+      end
+      expect(received).to eql 'Hello world'
+    end
+  end
+
   context 'with pathname destination' do
     let(:dest) { Pathname.new(File.join(Dir.mktmpdir, 'test-path.txt')) }
     let(:received) do

--- a/google-apis-core/spec/google/apis/core/storage_download_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_download_spec.rb
@@ -135,4 +135,25 @@ RSpec.describe Google::Apis::Core::StorageDownloadCommand do
       end
     end
   end
+
+  context 'with streaming response' do
+    let(:dest) { Tempfile.new('test') }
+    let(:received) do
+      command.execute(client)
+      dest.rewind
+      dest.read
+    end
+
+    it 'should receive content' do
+      response = Faraday::Response.new(status: 200, body: 'Hello world')
+      expect(client).to receive(:get) do |_url, _params, _headers, &block|
+        request = Faraday::Request.new
+        request.options = Faraday::RequestOptions.new
+        block.call(request)
+        request.options.on_data.call('Hello world', 11, nil)
+        response
+      end
+      expect(received).to eql 'Hello world'
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/googleapis/google-api-ruby-client/commit/cdf6281c73318b4467e2d99c27ebee2260750f3a#diff-81af43dded9cb6b9079107b8c2003553e23df305cfbae8c59ba69407feb09890

Fixes `NoMethodError` during streaming downloads when using Faraday 2.x with an adapter like typhoeus. 

Issue: https://github.com/googleapis/google-cloud-ruby/issues/30902 

Tested locally using `google-cloud-storage`