### PR TITLE
storage(feat): Add accept encoding gzip for media operation only

### DIFF
--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -262,6 +262,7 @@ module Google
           end
           batch_command.execute(client)
         end
+        
         # Get the current HTTP connection
         # @return [Faraday::Connection]
         def client

--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -262,7 +262,7 @@ module Google
           end
           batch_command.execute(client)
         end
-        
+
         # Get the current HTTP connection
         # @return [Faraday::Connection]
         def client

--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -262,7 +262,6 @@ module Google
           end
           batch_command.execute(client)
         end
-
         # Get the current HTTP connection
         # @return [Faraday::Connection]
         def client
@@ -420,6 +419,7 @@ module Google
           verify_universe_domain!
           template = Addressable::Template.new(root_url + upload_path + path)
           command = StorageUploadCommand.new(method, template, client_version: client_version)
+          command.header["Accept-Encoding"] ||= "gzip"
           command.options = request_options.merge(options)
           apply_command_defaults(command)
           command
@@ -458,6 +458,7 @@ module Google
           verify_universe_domain!
           template = Addressable::Template.new(root_url + base_path + path)
           command = StorageDownloadCommand.new(method, template, client_version: client_version)
+          command.header["Accept-Encoding"] ||= "gzip"
           command.options = request_options.merge(options)
           command.query['alt'] = 'media'
           apply_command_defaults(command)

--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -422,7 +422,9 @@ module Google
           command = StorageUploadCommand.new(method, template, client_version: client_version)
           command.options = request_options.merge(options)
           command.options.header = command.options.header&.dup || {}
-          command.options.header['Accept-Encoding'] ||= 'gzip'
+          unless command.options.header.any? { |k, _| k.to_s.casecmp('accept-encoding') == 0 }
+            command.options.header['Accept-Encoding'] = 'gzip'
+          end
           apply_command_defaults(command)
           command
         end
@@ -462,7 +464,9 @@ module Google
           command = StorageDownloadCommand.new(method, template, client_version: client_version)
           command.options = request_options.merge(options)
           command.options.header = command.options.header&.dup || {}
-          command.options.header['Accept-Encoding'] ||= 'gzip'
+          unless command.options.header.any? { |k, _| k.to_s.casecmp('accept-encoding') == 0 }
+            command.options.header['Accept-Encoding'] = 'gzip'
+          end
           command.query['alt'] = 'media'
           apply_command_defaults(command)
           command

--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -420,8 +420,9 @@ module Google
           verify_universe_domain!
           template = Addressable::Template.new(root_url + upload_path + path)
           command = StorageUploadCommand.new(method, template, client_version: client_version)
-          command.header["Accept-Encoding"] ||= "gzip"
           command.options = request_options.merge(options)
+          command.options.header = command.options.header&.dup || {}
+          command.options.header['Accept-Encoding'] ||= 'gzip'
           apply_command_defaults(command)
           command
         end
@@ -459,8 +460,9 @@ module Google
           verify_universe_domain!
           template = Addressable::Template.new(root_url + base_path + path)
           command = StorageDownloadCommand.new(method, template, client_version: client_version)
-          command.header["Accept-Encoding"] ||= "gzip"
           command.options = request_options.merge(options)
+          command.options.header = command.options.header&.dup || {}
+          command.options.header['Accept-Encoding'] ||= 'gzip'
           command.query['alt'] = 'media'
           apply_command_defaults(command)
           command

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -140,6 +140,10 @@ RSpec.describe Google::Apis::Core::BaseService do
       end.to raise_error(Google::Apis::UniverseDomainError)
     end
 
+    it 'should not include Accept-Encoding header' do
+      expect(command.header['Accept-Encoding']).to be_nil
+    end
+
     include_examples 'with options'
   end
 
@@ -173,6 +177,10 @@ RSpec.describe Google::Apis::Core::BaseService do
       expect(command.query).to include('alt' => 'media')
     end
 
+    it 'should not include Accept-Encoding header' do
+      expect(command.header['Accept-Encoding']).to_not eq('gzip')
+    end
+
     include_examples 'with options'
   end
 
@@ -192,6 +200,10 @@ RSpec.describe Google::Apis::Core::BaseService do
       expect(command.query).to include('alt' => 'media')
     end
 
+    it 'should include Accept-Encoding header' do
+      expect(command.header['Accept-Encoding']).to eq('gzip')
+    end
+
     include_examples 'with options'
   end
 
@@ -207,6 +219,10 @@ RSpec.describe Google::Apis::Core::BaseService do
       expect(url).to eql 'https://www.googleapis.com/upload/zoo/animals'
     end
 
+    it 'should not include Accept-Encoding header' do
+      expect(command.header['Accept-Encoding']).to be_nil
+    end
+
     include_examples 'with options'
   end
 
@@ -220,6 +236,10 @@ RSpec.describe Google::Apis::Core::BaseService do
     it 'should build a correct URL' do
       url = command.url.expand({}).to_s
       expect(url).to eql 'https://www.googleapis.com/upload/zoo/animals'
+    end
+
+    it 'should include Accept-Encoding header' do
+      expect(command.header['Accept-Encoding']).to eq('gzip')
     end
 
     include_examples 'with options'
@@ -263,6 +283,7 @@ RSpec.describe Google::Apis::Core::BaseService do
         command
         expect(a_request(:put, upload_url)).to have_been_made.twice
       end
+
     end
     context 'not restart resumable upload if upload is completed' do
       before(:example) do
@@ -429,6 +450,7 @@ Content-Length: \\d+
 Content-Transfer-Encoding: binary
 
 POST /upload/zoo/animals\\? HTTP/1\\.1
+Accept-Encoding: gzip
 X-Goog-Api-Client: #{Regexp.escape(x_goog_api_client_value)}
 Content-Type: multipart/related; boundary=inner
 X-Goog-Upload-Protocol: multipart

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -187,21 +187,21 @@ RSpec.describe Google::Apis::Core::BaseService do
   context 'when making storage download commands' do
     let(:command) { service.send(:make_storage_download_command, :get, 'zoo/animals', authorization: 'foo') }
 
-    it 'should return the correct command type' do
-      expect(command).to be_an_instance_of(Google::Apis::Core::StorageDownloadCommand)
-    end
+    # it 'should return the correct command type' do
+    #   expect(command).to be_an_instance_of(Google::Apis::Core::StorageDownloadCommand)
+    # end
 
-    it 'should build a correct URL' do
-      url = command.url.expand({}).to_s
-      expect(url).to eql 'https://www.googleapis.com/zoo/animals'
-    end
+    # it 'should build a correct URL' do
+    #   url = command.url.expand({}).to_s
+    #   expect(url).to eql 'https://www.googleapis.com/zoo/animals'
+    # end
 
-    it 'should include alt=media in params' do
-      expect(command.query).to include('alt' => 'media')
-    end
+    # it 'should include alt=media in params' do
+    #   expect(command.query).to include('alt' => 'media')
+    # end
 
     it 'should include Accept-Encoding header' do
-      expect(command.header['Accept-Encoding']).to eq('gzip')
+      expect(command.options.header['Accept-Encoding']).to eq('gzip')
     end
 
     include_examples 'with options'
@@ -239,7 +239,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should include Accept-Encoding header' do
-      expect(command.header['Accept-Encoding']).to eq('gzip')
+      expect(command.options.header['Accept-Encoding']).to eq('gzip')
     end
 
     include_examples 'with options'
@@ -284,6 +284,11 @@ RSpec.describe Google::Apis::Core::BaseService do
         expect(a_request(:put, upload_url)).to have_been_made.twice
       end
 
+      it 'should include an accept-encoding header' do
+        command
+        expect(a_request(:put, upload_url).with { |req| req.headers['Accept-Encoding'] == 'gzip' }).to have_been_made.twice
+      end
+
     end
     context 'not restart resumable upload if upload is completed' do
       before(:example) do
@@ -306,6 +311,11 @@ RSpec.describe Google::Apis::Core::BaseService do
       it 'should not restart a upload' do
         command
         expect(a_request(:put, upload_url)).to have_been_made
+      end
+
+      it 'should include an accept-encoding header' do
+        command
+        expect(a_request(:put, upload_url).with { |req| req.headers['Accept-Encoding'] == 'gzip' }).to have_been_made
       end
     end
   end
@@ -450,7 +460,6 @@ Content-Length: \\d+
 Content-Transfer-Encoding: binary
 
 POST /upload/zoo/animals\\? HTTP/1\\.1
-Accept-Encoding: gzip
 X-Goog-Api-Client: #{Regexp.escape(x_goog_api_client_value)}
 Content-Type: multipart/related; boundary=inner
 X-Goog-Upload-Protocol: multipart

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -187,18 +187,18 @@ RSpec.describe Google::Apis::Core::BaseService do
   context 'when making storage download commands' do
     let(:command) { service.send(:make_storage_download_command, :get, 'zoo/animals', authorization: 'foo') }
 
-    # it 'should return the correct command type' do
-    #   expect(command).to be_an_instance_of(Google::Apis::Core::StorageDownloadCommand)
-    # end
+    it 'should return the correct command type' do
+      expect(command).to be_an_instance_of(Google::Apis::Core::StorageDownloadCommand)
+    end
 
-    # it 'should build a correct URL' do
-    #   url = command.url.expand({}).to_s
-    #   expect(url).to eql 'https://www.googleapis.com/zoo/animals'
-    # end
+    it 'should build a correct URL' do
+      url = command.url.expand({}).to_s
+      expect(url).to eql 'https://www.googleapis.com/zoo/animals'
+    end
 
-    # it 'should include alt=media in params' do
-    #   expect(command.query).to include('alt' => 'media')
-    # end
+    it 'should include alt=media in params' do
+      expect(command.query).to include('alt' => 'media')
+    end
 
     it 'should include Accept-Encoding header' do
       expect(command.options.header['Accept-Encoding']).to eq('gzip')

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should not include Accept-Encoding header' do
-      expect(command.header['Accept-Encoding']).to_not eq('gzip')
+      expect(command.options.header['Accept-Encoding']).to be_nil
     end
 
     include_examples 'with options'
@@ -220,7 +220,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should not include Accept-Encoding header' do
-      expect(command.header['Accept-Encoding']).to be_nil
+      expect(command.options.header['Accept-Encoding']).to be_nil
     end
 
     include_examples 'with options'

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should not include Accept-Encoding header' do
-      expect(command.header['Accept-Encoding']).to be_nil
+      expect(command.options.header&.[]('Accept-Encoding')).to be_nil
     end
 
     include_examples 'with options'
@@ -178,7 +178,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should not include Accept-Encoding header' do
-      expect(command.options.header['Accept-Encoding']).to be_nil
+      expect(command.options.header&.[]('Accept-Encoding')).to be_nil
     end
 
     include_examples 'with options'
@@ -220,7 +220,7 @@ RSpec.describe Google::Apis::Core::BaseService do
     end
 
     it 'should not include Accept-Encoding header' do
-      expect(command.options.header['Accept-Encoding']).to be_nil
+      expect(command.options.header&.[]('Accept-Encoding')).to be_nil
     end
 
     include_examples 'with options'

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe Google::Apis::Core::BaseService do
       expect(command.options.header['Accept-Encoding']).to eq('gzip')
     end
 
+    ['ACCEPT-ENCODING', 'Accept-Encoding', 'accept-encoding', :'ACCEPT-ENCODING', :'Accept-Encoding', :'accept-encoding'].each do |header_key|
+      it "should respect alternative capitalization/type of Accept-Encoding for #{header_key}" do
+        cmd = service.send(:make_storage_download_command, :get, 'zoo/animals', header: { header_key => 'identity' })
+        expect(cmd.options.header[header_key]).to eq('identity')
+        expect(cmd.options.header.keys.count { |k| k.to_s.casecmp('accept-encoding') == 0 }).to eq(1)
+      end
+    end
+
     include_examples 'with options'
   end
 
@@ -240,6 +248,14 @@ RSpec.describe Google::Apis::Core::BaseService do
 
     it 'should include Accept-Encoding header' do
       expect(command.options.header['Accept-Encoding']).to eq('gzip')
+    end
+
+    ['ACCEPT-ENCODING', 'Accept-Encoding', 'accept-encoding', :'ACCEPT-ENCODING', :'Accept-Encoding', :'accept-encoding'].each do |header_key|
+      it "should respect alternative capitalization/type of Accept-Encoding for #{header_key}" do
+        cmd = service.send(:make_storage_upload_command, :post, 'zoo/animals', header: { header_key => 'identity' })
+        expect(cmd.options.header[header_key]).to eq('identity')
+        expect(cmd.options.header.keys.count { |k| k.to_s.casecmp('accept-encoding') == 0 }).to eq(1)
+      end
     end
 
     include_examples 'with options'

--- a/google-apis-core/spec/google/apis/core/storage_download_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_download_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Google::Apis::Core::StorageDownloadCommand do
               ).to have_been_made
       end
 
+      it 'should include a accept-encoding header' do
+        command.execute(client)
+        expect(a_request(:get, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers.key?('Accept-Encoding') }
+              ).to have_been_made
+      end
+
       it 'should receive content' do
         expect(received).to eql 'Hello world'
       end

--- a/google-apis-core/spec/google/apis/core/storage_download_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_download_spec.rb
@@ -42,11 +42,10 @@ RSpec.describe Google::Apis::Core::StorageDownloadCommand do
               ).to have_been_made
       end
 
-      it 'should include a accept-encoding header' do
+      it 'should include an Accept-Encoding header for media downloads' do
         command.execute(client)
         expect(a_request(:get, 'https://www.googleapis.com/zoo/animals')
-          .with { |req| req.headers.key?('Accept-Encoding') }
-              ).to have_been_made
+          .with { |req| req.headers['Accept-Encoding'].include?('gzip') }).to have_been_made
       end
 
       it 'should receive content' do

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -69,11 +69,10 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         .with(body: 'Hello world')).to have_been_made
     end
 
-    it 'should include an accept-encoding header' do
+    it 'should include an Accept-Encoding header in the outgoing request' do
       command.execute(client)
       expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
-        .with { |req| req.headers['Accept-Encoding'] = 'gzip' }
-            ).to have_been_made
+        .with { |req| req.headers['Accept-Encoding'].include?('gzip') }).to have_been_made
     end
   end
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -68,6 +68,13 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
         .with(body: 'Hello world')).to have_been_made
     end
+
+    it 'should include an accept-encoding header' do
+      command.execute(client)
+      expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+        .with { |req| req.headers['Accept-Encoding'] = 'gzip' }
+            ).to have_been_made
+    end
   end
 
   context('with StringIO input') do


### PR DESCRIPTION
This pull request adds the Accept-Encoding: gzip header to storage upload and download commands and includes corresponding unit tests.

Associated Storage library Pr: https://github.com/googleapis/google-cloud-ruby/pull/33896