### PR TITLE
feat: migrate to Ruby 3.2+ as minimum supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            task: "--include-spec"
-          - os: ubuntu-latest
             ruby: "3.2"
             task: "--include-spec"
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ services.
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
-Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Currently, this means Ruby 2.7 and later. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
+Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Currently, this means Ruby 3.2 and later. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 
 ## License
 

--- a/generated/google-apis-abusiveexperiencereport_v1/OVERVIEW.md
+++ b/generated/google-apis-abusiveexperiencereport_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/abusive-experience-rep
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-abusiveexperiencereport_v1/google-apis-abusiveexperiencereport_v1.gemspec
+++ b/generated/google-apis-abusiveexperiencereport_v1/google-apis-abusiveexperiencereport_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-acceleratedmobilepageurl_v1/OVERVIEW.md
+++ b/generated/google-apis-acceleratedmobilepageurl_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/amp/cache/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-acceleratedmobilepageurl_v1/google-apis-acceleratedmobilepageurl_v1.gemspec
+++ b/generated/google-apis-acceleratedmobilepageurl_v1/google-apis-acceleratedmobilepageurl_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-accessapproval_v1/OVERVIEW.md
+++ b/generated/google-apis-accessapproval_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/assured-workloads/access-ap
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-accessapproval_v1/google-apis-accessapproval_v1.gemspec
+++ b/generated/google-apis-accessapproval_v1/google-apis-accessapproval_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-accesscontextmanager_v1/OVERVIEW.md
+++ b/generated/google-apis-accesscontextmanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/access-context-manager/docs
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-accesscontextmanager_v1/google-apis-accesscontextmanager_v1.gemspec
+++ b/generated/google-apis-accesscontextmanager_v1/google-apis-accesscontextmanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-addressvalidation_v1/OVERVIEW.md
+++ b/generated/google-apis-addressvalidation_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/maps/documentation/add
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-addressvalidation_v1/google-apis-addressvalidation_v1.gemspec
+++ b/generated/google-apis-addressvalidation_v1/google-apis-addressvalidation_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-adexchangebuyer2_v2beta1/OVERVIEW.md
+++ b/generated/google-apis-adexchangebuyer2_v2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/authorized-buyers/apis
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-adexchangebuyer2_v2beta1/google-apis-adexchangebuyer2_v2beta1.gemspec
+++ b/generated/google-apis-adexchangebuyer2_v2beta1/google-apis-adexchangebuyer2_v2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-adexperiencereport_v1/OVERVIEW.md
+++ b/generated/google-apis-adexperiencereport_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/ad-experience-report/)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-adexperiencereport_v1/google-apis-adexperiencereport_v1.gemspec
+++ b/generated/google-apis-adexperiencereport_v1/google-apis-adexperiencereport_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-admin_datatransfer_v1/OVERVIEW.md
+++ b/generated/google-apis-admin_datatransfer_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/admin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-admin_datatransfer_v1/google-apis-admin_datatransfer_v1.gemspec
+++ b/generated/google-apis-admin_datatransfer_v1/google-apis-admin_datatransfer_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-admin_directory_v1/OVERVIEW.md
+++ b/generated/google-apis-admin_directory_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/admin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-admin_directory_v1/google-apis-admin_directory_v1.gemspec
+++ b/generated/google-apis-admin_directory_v1/google-apis-admin_directory_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-admin_reports_v1/OVERVIEW.md
+++ b/generated/google-apis-admin_reports_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/admin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-admin_reports_v1/google-apis-admin_reports_v1.gemspec
+++ b/generated/google-apis-admin_reports_v1/google-apis-admin_reports_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-admob_v1/OVERVIEW.md
+++ b/generated/google-apis-admob_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/admob/api/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-admob_v1/google-apis-admob_v1.gemspec
+++ b/generated/google-apis-admob_v1/google-apis-admob_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-admob_v1beta/OVERVIEW.md
+++ b/generated/google-apis-admob_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/admob/api/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-admob_v1beta/google-apis-admob_v1beta.gemspec
+++ b/generated/google-apis-admob_v1beta/google-apis-admob_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-adsense_v2/OVERVIEW.md
+++ b/generated/google-apis-adsense_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/adsense/management/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-adsense_v2/google-apis-adsense_v2.gemspec
+++ b/generated/google-apis-adsense_v2/google-apis-adsense_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-adsenseplatform_v1/OVERVIEW.md
+++ b/generated/google-apis-adsenseplatform_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/adsense/platforms/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-adsenseplatform_v1/google-apis-adsenseplatform_v1.gemspec
+++ b/generated/google-apis-adsenseplatform_v1/google-apis-adsenseplatform_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-adsenseplatform_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-adsenseplatform_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/adsense/platforms/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-adsenseplatform_v1alpha/google-apis-adsenseplatform_v1alpha.gemspec
+++ b/generated/google-apis-adsenseplatform_v1alpha/google-apis-adsenseplatform_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-advisorynotifications_v1/OVERVIEW.md
+++ b/generated/google-apis-advisorynotifications_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/advisory-notifications) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-advisorynotifications_v1/google-apis-advisorynotifications_v1.gemspec
+++ b/generated/google-apis-advisorynotifications_v1/google-apis-advisorynotifications_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-agentregistry_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-agentregistry_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/agent-registry/overvie
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-agentregistry_v1alpha/google-apis-agentregistry_v1alpha.gemspec
+++ b/generated/google-apis-agentregistry_v1alpha/google-apis-agentregistry_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-aiplatform_v1/OVERVIEW.md
+++ b/generated/google-apis-aiplatform_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vertex-ai/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-aiplatform_v1/google-apis-aiplatform_v1.gemspec
+++ b/generated/google-apis-aiplatform_v1/google-apis-aiplatform_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-aiplatform_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-aiplatform_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vertex-ai/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-aiplatform_v1beta1/google-apis-aiplatform_v1beta1.gemspec
+++ b/generated/google-apis-aiplatform_v1beta1/google-apis-aiplatform_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-airquality_v1/OVERVIEW.md
+++ b/generated/google-apis-airquality_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/maps/documentation/air
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-airquality_v1/google-apis-airquality_v1.gemspec
+++ b/generated/google-apis-airquality_v1/google-apis-airquality_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-alertcenter_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-alertcenter_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/admin/alertc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-alertcenter_v1beta1/google-apis-alertcenter_v1beta1.gemspec
+++ b/generated/google-apis-alertcenter_v1beta1/google-apis-alertcenter_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-alloydb_v1/OVERVIEW.md
+++ b/generated/google-apis-alloydb_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/alloydb/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-alloydb_v1/google-apis-alloydb_v1.gemspec
+++ b/generated/google-apis-alloydb_v1/google-apis-alloydb_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-alloydb_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-alloydb_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/alloydb/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-alloydb_v1alpha/google-apis-alloydb_v1alpha.gemspec
+++ b/generated/google-apis-alloydb_v1alpha/google-apis-alloydb_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-alloydb_v1beta/OVERVIEW.md
+++ b/generated/google-apis-alloydb_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/alloydb/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-alloydb_v1beta/google-apis-alloydb_v1beta.gemspec
+++ b/generated/google-apis-alloydb_v1beta/google-apis-alloydb_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analytics_v3/OVERVIEW.md
+++ b/generated/google-apis-analytics_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/analytics/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analytics_v3/google-apis-analytics_v3.gemspec
+++ b/generated/google-apis-analytics_v3/google-apis-analytics_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analyticsadmin_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-analyticsadmin_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://code.google.com/apis/analytics/docs/mgmt/home
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analyticsadmin_v1alpha/google-apis-analyticsadmin_v1alpha.gemspec
+++ b/generated/google-apis-analyticsadmin_v1alpha/google-apis-analyticsadmin_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analyticsadmin_v1beta/OVERVIEW.md
+++ b/generated/google-apis-analyticsadmin_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://code.google.com/apis/analytics/docs/mgmt/home
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analyticsadmin_v1beta/google-apis-analyticsadmin_v1beta.gemspec
+++ b/generated/google-apis-analyticsadmin_v1beta/google-apis-analyticsadmin_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analyticsdata_v1beta/OVERVIEW.md
+++ b/generated/google-apis-analyticsdata_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/analytics/devguides/re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analyticsdata_v1beta/google-apis-analyticsdata_v1beta.gemspec
+++ b/generated/google-apis-analyticsdata_v1beta/google-apis-analyticsdata_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analyticshub_v1/OVERVIEW.md
+++ b/generated/google-apis-analyticshub_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/analytics-hub
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analyticshub_v1/google-apis-analyticshub_v1.gemspec
+++ b/generated/google-apis-analyticshub_v1/google-apis-analyticshub_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-analyticshub_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-analyticshub_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/analytics-hub
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-analyticshub_v1beta1/google-apis-analyticshub_v1beta1.gemspec
+++ b/generated/google-apis-analyticshub_v1beta1/google-apis-analyticshub_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-androiddeviceprovisioning_v1/OVERVIEW.md
+++ b/generated/google-apis-androiddeviceprovisioning_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/zero-touch/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-androiddeviceprovisioning_v1/google-apis-androiddeviceprovisioning_v1.gemspec
+++ b/generated/google-apis-androiddeviceprovisioning_v1/google-apis-androiddeviceprovisioning_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-androidenterprise_v1/OVERVIEW.md
+++ b/generated/google-apis-androidenterprise_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/android/work/play/emm-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-androidenterprise_v1/google-apis-androidenterprise_v1.gemspec
+++ b/generated/google-apis-androidenterprise_v1/google-apis-androidenterprise_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-androidmanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-androidmanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/android/management) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-androidmanagement_v1/google-apis-androidmanagement_v1.gemspec
+++ b/generated/google-apis-androidmanagement_v1/google-apis-androidmanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-androidpublisher_v3/OVERVIEW.md
+++ b/generated/google-apis-androidpublisher_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/android-publisher) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-androidpublisher_v3/google-apis-androidpublisher_v3.gemspec
+++ b/generated/google-apis-androidpublisher_v3/google-apis-androidpublisher_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apigateway_v1/OVERVIEW.md
+++ b/generated/google-apis-apigateway_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/api-gateway/docs) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apigateway_v1/google-apis-apigateway_v1.gemspec
+++ b/generated/google-apis-apigateway_v1/google-apis-apigateway_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apigateway_v1beta/OVERVIEW.md
+++ b/generated/google-apis-apigateway_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/api-gateway/docs) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apigateway_v1beta/google-apis-apigateway_v1beta.gemspec
+++ b/generated/google-apis-apigateway_v1beta/google-apis-apigateway_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apigee_v1/OVERVIEW.md
+++ b/generated/google-apis-apigee_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee-api-management/) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apigee_v1/google-apis-apigee_v1.gemspec
+++ b/generated/google-apis-apigee_v1/google-apis-apigee_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apigeeregistry_v1/OVERVIEW.md
+++ b/generated/google-apis-apigeeregistry_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee/docs/api-hub/what-is
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apigeeregistry_v1/google-apis-apigeeregistry_v1.gemspec
+++ b/generated/google-apis-apigeeregistry_v1/google-apis-apigeeregistry_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apihub_v1/OVERVIEW.md
+++ b/generated/google-apis-apihub_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee/docs/api-hub/what-is
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apihub_v1/google-apis-apihub_v1.gemspec
+++ b/generated/google-apis-apihub_v1/google-apis-apihub_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apikeys_v2/OVERVIEW.md
+++ b/generated/google-apis-apikeys_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/api-keys/docs) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apikeys_v2/google-apis-apikeys_v2.gemspec
+++ b/generated/google-apis-apikeys_v2/google-apis-apikeys_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apim_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-apim_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apim_v1alpha/google-apis-apim_v1alpha.gemspec
+++ b/generated/google-apis-apim_v1alpha/google-apis-apim_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-appengine_v1/OVERVIEW.md
+++ b/generated/google-apis-appengine_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/appengine/docs/admin-api/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-appengine_v1/google-apis-appengine_v1.gemspec
+++ b/generated/google-apis-appengine_v1/google-apis-appengine_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-appengine_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-appengine_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/appengine/docs/admin-api/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-appengine_v1alpha/google-apis-appengine_v1alpha.gemspec
+++ b/generated/google-apis-appengine_v1alpha/google-apis-appengine_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-appengine_v1beta/OVERVIEW.md
+++ b/generated/google-apis-appengine_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/appengine/docs/admin-api/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-appengine_v1beta/google-apis-appengine_v1beta.gemspec
+++ b/generated/google-apis-appengine_v1beta/google-apis-appengine_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apphub_v1/OVERVIEW.md
+++ b/generated/google-apis-apphub_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/app-hub/docs/) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apphub_v1/google-apis-apphub_v1.gemspec
+++ b/generated/google-apis-apphub_v1/google-apis-apphub_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-apphub_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-apphub_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/app-hub/docs/) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-apphub_v1alpha/google-apis-apphub_v1alpha.gemspec
+++ b/generated/google-apis-apphub_v1alpha/google-apis-apphub_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-appsmarket_v2/OVERVIEW.md
+++ b/generated/google-apis-appsmarket_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/marketplace)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-appsmarket_v2/google-apis-appsmarket_v2.gemspec
+++ b/generated/google-apis-appsmarket_v2/google-apis-appsmarket_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-area120tables_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-area120tables_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://support.google.com/area120-tables/answer/100
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-area120tables_v1alpha1/google-apis-area120tables_v1alpha1.gemspec
+++ b/generated/google-apis-area120tables_v1alpha1/google-apis-area120tables_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-areainsights_v1/OVERVIEW.md
+++ b/generated/google-apis-areainsights_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/maps/documentation/pla
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-areainsights_v1/google-apis-areainsights_v1.gemspec
+++ b/generated/google-apis-areainsights_v1/google-apis-areainsights_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-artifactregistry_v1/OVERVIEW.md
+++ b/generated/google-apis-artifactregistry_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/artifacts/docs/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-artifactregistry_v1/google-apis-artifactregistry_v1.gemspec
+++ b/generated/google-apis-artifactregistry_v1/google-apis-artifactregistry_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-artifactregistry_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-artifactregistry_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/artifacts/docs/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-artifactregistry_v1beta1/google-apis-artifactregistry_v1beta1.gemspec
+++ b/generated/google-apis-artifactregistry_v1beta1/google-apis-artifactregistry_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-artifactregistry_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-artifactregistry_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/artifacts/docs/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-artifactregistry_v1beta2/google-apis-artifactregistry_v1beta2.gemspec
+++ b/generated/google-apis-artifactregistry_v1beta2/google-apis-artifactregistry_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-assuredworkloads_v1/OVERVIEW.md
+++ b/generated/google-apis-assuredworkloads_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/learnmoreurl) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-assuredworkloads_v1/google-apis-assuredworkloads_v1.gemspec
+++ b/generated/google-apis-assuredworkloads_v1/google-apis-assuredworkloads_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-assuredworkloads_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-assuredworkloads_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/learnmoreurl) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-assuredworkloads_v1beta1/google-apis-assuredworkloads_v1beta1.gemspec
+++ b/generated/google-apis-assuredworkloads_v1beta1/google-apis-assuredworkloads_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-authorizedbuyersmarketplace_v1/OVERVIEW.md
+++ b/generated/google-apis-authorizedbuyersmarketplace_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/authorized-buyers/apis
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-authorizedbuyersmarketplace_v1/google-apis-authorizedbuyersmarketplace_v1.gemspec
+++ b/generated/google-apis-authorizedbuyersmarketplace_v1/google-apis-authorizedbuyersmarketplace_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-authorizedbuyersmarketplace_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-authorizedbuyersmarketplace_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/authorized-buyers/apis
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-authorizedbuyersmarketplace_v1alpha/google-apis-authorizedbuyersmarketplace_v1alpha.gemspec
+++ b/generated/google-apis-authorizedbuyersmarketplace_v1alpha/google-apis-authorizedbuyersmarketplace_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-backupdr_v1/OVERVIEW.md
+++ b/generated/google-apis-backupdr_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/backup-disaster-recovery) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-backupdr_v1/google-apis-backupdr_v1.gemspec
+++ b/generated/google-apis-backupdr_v1/google-apis-backupdr_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-baremetalsolution_v2/OVERVIEW.md
+++ b/generated/google-apis-baremetalsolution_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bare-metal) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-baremetalsolution_v2/google-apis-baremetalsolution_v2.gemspec
+++ b/generated/google-apis-baremetalsolution_v2/google-apis-baremetalsolution_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-batch_v1/OVERVIEW.md
+++ b/generated/google-apis-batch_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/batch/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-batch_v1/google-apis-batch_v1.gemspec
+++ b/generated/google-apis-batch_v1/google-apis-batch_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-beyondcorp_v1/OVERVIEW.md
+++ b/generated/google-apis-beyondcorp_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-beyondcorp_v1/google-apis-beyondcorp_v1.gemspec
+++ b/generated/google-apis-beyondcorp_v1/google-apis-beyondcorp_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-beyondcorp_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-beyondcorp_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-beyondcorp_v1alpha/google-apis-beyondcorp_v1alpha.gemspec
+++ b/generated/google-apis-beyondcorp_v1alpha/google-apis-beyondcorp_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-biglake_v1/OVERVIEW.md
+++ b/generated/google-apis-biglake_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-biglake_v1/google-apis-biglake_v1.gemspec
+++ b/generated/google-apis-biglake_v1/google-apis-biglake_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigquery_v2/OVERVIEW.md
+++ b/generated/google-apis-bigquery_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigquery_v2/google-apis-bigquery_v2.gemspec
+++ b/generated/google-apis-bigquery_v2/google-apis-bigquery_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigqueryconnection_v1/OVERVIEW.md
+++ b/generated/google-apis-bigqueryconnection_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/connections-a
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigqueryconnection_v1/google-apis-bigqueryconnection_v1.gemspec
+++ b/generated/google-apis-bigqueryconnection_v1/google-apis-bigqueryconnection_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigqueryconnection_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-bigqueryconnection_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/connections-a
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigqueryconnection_v1beta1/google-apis-bigqueryconnection_v1beta1.gemspec
+++ b/generated/google-apis-bigqueryconnection_v1beta1/google-apis-bigqueryconnection_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigquerydatapolicy_v1/OVERVIEW.md
+++ b/generated/google-apis-bigquerydatapolicy_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/column-data-m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigquerydatapolicy_v1/google-apis-bigquerydatapolicy_v1.gemspec
+++ b/generated/google-apis-bigquerydatapolicy_v1/google-apis-bigquerydatapolicy_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigquerydatapolicy_v2/OVERVIEW.md
+++ b/generated/google-apis-bigquerydatapolicy_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/docs/column-data-m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigquerydatapolicy_v2/google-apis-bigquerydatapolicy_v2.gemspec
+++ b/generated/google-apis-bigquerydatapolicy_v2/google-apis-bigquerydatapolicy_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigquerydatatransfer_v1/OVERVIEW.md
+++ b/generated/google-apis-bigquerydatatransfer_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery-transfer/) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigquerydatatransfer_v1/google-apis-bigquerydatatransfer_v1.gemspec
+++ b/generated/google-apis-bigquerydatatransfer_v1/google-apis-bigquerydatatransfer_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigqueryreservation_v1/OVERVIEW.md
+++ b/generated/google-apis-bigqueryreservation_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigquery/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigqueryreservation_v1/google-apis-bigqueryreservation_v1.gemspec
+++ b/generated/google-apis-bigqueryreservation_v1/google-apis-bigqueryreservation_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-bigtableadmin_v2/OVERVIEW.md
+++ b/generated/google-apis-bigtableadmin_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/bigtable/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-bigtableadmin_v2/google-apis-bigtableadmin_v2.gemspec
+++ b/generated/google-apis-bigtableadmin_v2/google-apis-bigtableadmin_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-billingbudgets_v1/OVERVIEW.md
+++ b/generated/google-apis-billingbudgets_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/billing/docs/how-to/budget-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-billingbudgets_v1/google-apis-billingbudgets_v1.gemspec
+++ b/generated/google-apis-billingbudgets_v1/google-apis-billingbudgets_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-billingbudgets_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-billingbudgets_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/billing/docs/how-to/budget-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-billingbudgets_v1beta1/google-apis-billingbudgets_v1beta1.gemspec
+++ b/generated/google-apis-billingbudgets_v1beta1/google-apis-billingbudgets_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-binaryauthorization_v1/OVERVIEW.md
+++ b/generated/google-apis-binaryauthorization_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/binary-authorization/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-binaryauthorization_v1/google-apis-binaryauthorization_v1.gemspec
+++ b/generated/google-apis-binaryauthorization_v1/google-apis-binaryauthorization_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-binaryauthorization_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-binaryauthorization_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/binary-authorization/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-binaryauthorization_v1beta1/google-apis-binaryauthorization_v1beta1.gemspec
+++ b/generated/google-apis-binaryauthorization_v1beta1/google-apis-binaryauthorization_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-blockchainnodeengine_v1/OVERVIEW.md
+++ b/generated/google-apis-blockchainnodeengine_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/blockchain-node-engine) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-blockchainnodeengine_v1/google-apis-blockchainnodeengine_v1.gemspec
+++ b/generated/google-apis-blockchainnodeengine_v1/google-apis-blockchainnodeengine_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-blogger_v2/OVERVIEW.md
+++ b/generated/google-apis-blogger_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/blogger/docs/3.0/getti
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-blogger_v2/google-apis-blogger_v2.gemspec
+++ b/generated/google-apis-blogger_v2/google-apis-blogger_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-blogger_v3/OVERVIEW.md
+++ b/generated/google-apis-blogger_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/blogger/docs/3.0/getti
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-blogger_v3/google-apis-blogger_v3.gemspec
+++ b/generated/google-apis-blogger_v3/google-apis-blogger_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-books_v1/OVERVIEW.md
+++ b/generated/google-apis-books_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://code.google.com/apis/books/docs/v1/getting_s
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-books_v1/google-apis-books_v1.gemspec
+++ b/generated/google-apis-books_v1/google-apis-books_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-businessprofileperformance_v1/OVERVIEW.md
+++ b/generated/google-apis-businessprofileperformance_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-businessprofileperformance_v1/google-apis-businessprofileperformance_v1.gemspec
+++ b/generated/google-apis-businessprofileperformance_v1/google-apis-businessprofileperformance_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-calendar_v3/OVERVIEW.md
+++ b/generated/google-apis-calendar_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/calendar/fir
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-calendar_v3/google-apis-calendar_v3.gemspec
+++ b/generated/google-apis-calendar_v3/google-apis-calendar_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-certificatemanager_v1/OVERVIEW.md
+++ b/generated/google-apis-certificatemanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/certificate-manager/do
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-certificatemanager_v1/google-apis-certificatemanager_v1.gemspec
+++ b/generated/google-apis-certificatemanager_v1/google-apis-certificatemanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-ces_v1/OVERVIEW.md
+++ b/generated/google-apis-ces_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/customer-engagement-ai
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-ces_v1/google-apis-ces_v1.gemspec
+++ b/generated/google-apis-ces_v1/google-apis-ces_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chat_v1/OVERVIEW.md
+++ b/generated/google-apis-chat_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/chat) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chat_v1/google-apis-chat_v1.gemspec
+++ b/generated/google-apis-chat_v1/google-apis-chat_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-checks_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-checks_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/checks) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-checks_v1alpha/google-apis-checks_v1alpha.gemspec
+++ b/generated/google-apis-checks_v1alpha/google-apis-checks_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chromemanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-chromemanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/chrome/management/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chromemanagement_v1/google-apis-chromemanagement_v1.gemspec
+++ b/generated/google-apis-chromemanagement_v1/google-apis-chromemanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chromepolicy_v1/OVERVIEW.md
+++ b/generated/google-apis-chromepolicy_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://developers.google.com/chrome/policy) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chromepolicy_v1/google-apis-chromepolicy_v1.gemspec
+++ b/generated/google-apis-chromepolicy_v1/google-apis-chromepolicy_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chromeuxreport_v1/OVERVIEW.md
+++ b/generated/google-apis-chromeuxreport_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/web/tools/chrome-user-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chromeuxreport_v1/google-apis-chromeuxreport_v1.gemspec
+++ b/generated/google-apis-chromeuxreport_v1/google-apis-chromeuxreport_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chromewebstore_v1_1/OVERVIEW.md
+++ b/generated/google-apis-chromewebstore_v1_1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developer.chrome.com/docs/webstore/api) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chromewebstore_v1_1/google-apis-chromewebstore_v1_1.gemspec
+++ b/generated/google-apis-chromewebstore_v1_1/google-apis-chromewebstore_v1_1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-chromewebstore_v2/OVERVIEW.md
+++ b/generated/google-apis-chromewebstore_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developer.chrome.com/docs/webstore/api) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-chromewebstore_v2/google-apis-chromewebstore_v2.gemspec
+++ b/generated/google-apis-chromewebstore_v2/google-apis-chromewebstore_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-civicinfo_v2/OVERVIEW.md
+++ b/generated/google-apis-civicinfo_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/civic-information/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-civicinfo_v2/google-apis-civicinfo_v2.gemspec
+++ b/generated/google-apis-civicinfo_v2/google-apis-civicinfo_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-classroom_v1/OVERVIEW.md
+++ b/generated/google-apis-classroom_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/classroom/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-classroom_v1/google-apis-classroom_v1.gemspec
+++ b/generated/google-apis-classroom_v1/google-apis-classroom_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudasset_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudasset_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/asset-inventory/docs/quicks
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudasset_v1/google-apis-cloudasset_v1.gemspec
+++ b/generated/google-apis-cloudasset_v1/google-apis-cloudasset_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudasset_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudasset_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/asset-inventory/docs/quicks
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudasset_v1beta1/google-apis-cloudasset_v1beta1.gemspec
+++ b/generated/google-apis-cloudasset_v1beta1/google-apis-cloudasset_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudasset_v1p1beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudasset_v1p1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/asset-inventory/docs/quicks
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudasset_v1p1beta1/google-apis-cloudasset_v1p1beta1.gemspec
+++ b/generated/google-apis-cloudasset_v1p1beta1/google-apis-cloudasset_v1p1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudasset_v1p5beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudasset_v1p5beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/asset-inventory/docs/quicks
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudasset_v1p5beta1/google-apis-cloudasset_v1p5beta1.gemspec
+++ b/generated/google-apis-cloudasset_v1p5beta1/google-apis-cloudasset_v1p5beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudasset_v1p7beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudasset_v1p7beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/asset-inventory/docs/quicks
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudasset_v1p7beta1/google-apis-cloudasset_v1p7beta1.gemspec
+++ b/generated/google-apis-cloudasset_v1p7beta1/google-apis-cloudasset_v1p7beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudbilling_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudbilling_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/billing/docs/apis) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudbilling_v1/google-apis-cloudbilling_v1.gemspec
+++ b/generated/google-apis-cloudbilling_v1/google-apis-cloudbilling_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudbilling_v1beta/OVERVIEW.md
+++ b/generated/google-apis-cloudbilling_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/billing/docs/apis) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudbilling_v1beta/google-apis-cloudbilling_v1beta.gemspec
+++ b/generated/google-apis-cloudbilling_v1beta/google-apis-cloudbilling_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudbuild_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudbuild_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/cloud-build/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudbuild_v1/google-apis-cloudbuild_v1.gemspec
+++ b/generated/google-apis-cloudbuild_v1/google-apis-cloudbuild_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudbuild_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudbuild_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/cloud-build/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudbuild_v2/google-apis-cloudbuild_v2.gemspec
+++ b/generated/google-apis-cloudbuild_v2/google-apis-cloudbuild_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudchannel_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudchannel_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/channel) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudchannel_v1/google-apis-cloudchannel_v1.gemspec
+++ b/generated/google-apis-cloudchannel_v1/google-apis-cloudchannel_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudcommerceprocurement_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudcommerceprocurement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/marketplace/docs/partners/)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudcommerceprocurement_v1/google-apis-cloudcommerceprocurement_v1.gemspec
+++ b/generated/google-apis-cloudcommerceprocurement_v1/google-apis-cloudcommerceprocurement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudcontrolspartner_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudcontrolspartner_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/sovereign-controls-by-partn
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudcontrolspartner_v1/google-apis-cloudcontrolspartner_v1.gemspec
+++ b/generated/google-apis-cloudcontrolspartner_v1/google-apis-cloudcontrolspartner_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudcontrolspartner_v1beta/OVERVIEW.md
+++ b/generated/google-apis-cloudcontrolspartner_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/sovereign-controls-by-partn
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudcontrolspartner_v1beta/google-apis-cloudcontrolspartner_v1beta.gemspec
+++ b/generated/google-apis-cloudcontrolspartner_v1beta/google-apis-cloudcontrolspartner_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-clouddeploy_v1/OVERVIEW.md
+++ b/generated/google-apis-clouddeploy_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deploy/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-clouddeploy_v1/google-apis-clouddeploy_v1.gemspec
+++ b/generated/google-apis-clouddeploy_v1/google-apis-clouddeploy_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-clouderrorreporting_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-clouderrorreporting_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/error-reporting/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-clouderrorreporting_v1beta1/google-apis-clouderrorreporting_v1beta1.gemspec
+++ b/generated/google-apis-clouderrorreporting_v1beta1/google-apis-clouderrorreporting_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudfunctions_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudfunctions_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/functions) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudfunctions_v1/google-apis-cloudfunctions_v1.gemspec
+++ b/generated/google-apis-cloudfunctions_v1/google-apis-cloudfunctions_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudfunctions_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudfunctions_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/functions) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudfunctions_v2/google-apis-cloudfunctions_v2.gemspec
+++ b/generated/google-apis-cloudfunctions_v2/google-apis-cloudfunctions_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudfunctions_v2alpha/OVERVIEW.md
+++ b/generated/google-apis-cloudfunctions_v2alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/functions) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudfunctions_v2alpha/google-apis-cloudfunctions_v2alpha.gemspec
+++ b/generated/google-apis-cloudfunctions_v2alpha/google-apis-cloudfunctions_v2alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudfunctions_v2beta/OVERVIEW.md
+++ b/generated/google-apis-cloudfunctions_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/functions) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudfunctions_v2beta/google-apis-cloudfunctions_v2beta.gemspec
+++ b/generated/google-apis-cloudfunctions_v2beta/google-apis-cloudfunctions_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudidentity_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudidentity_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/identity/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudidentity_v1/google-apis-cloudidentity_v1.gemspec
+++ b/generated/google-apis-cloudidentity_v1/google-apis-cloudidentity_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudidentity_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudidentity_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/identity/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudidentity_v1beta1/google-apis-cloudidentity_v1beta1.gemspec
+++ b/generated/google-apis-cloudidentity_v1beta1/google-apis-cloudidentity_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudkms_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudkms_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/kms/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudkms_v1/google-apis-cloudkms_v1.gemspec
+++ b/generated/google-apis-cloudkms_v1/google-apis-cloudkms_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudlocationfinder_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudlocationfinder_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/location-finder/docs) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudlocationfinder_v1/google-apis-cloudlocationfinder_v1.gemspec
+++ b/generated/google-apis-cloudlocationfinder_v1/google-apis-cloudlocationfinder_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudlocationfinder_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-cloudlocationfinder_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/location-finder/docs) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudlocationfinder_v1alpha/google-apis-cloudlocationfinder_v1alpha.gemspec
+++ b/generated/google-apis-cloudlocationfinder_v1alpha/google-apis-cloudlocationfinder_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudnumberregistry_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-cloudnumberregistry_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/number-registry/refere
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudnumberregistry_v1alpha/google-apis-cloudnumberregistry_v1alpha.gemspec
+++ b/generated/google-apis-cloudnumberregistry_v1alpha/google-apis-cloudnumberregistry_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudprofiler_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudprofiler_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/profiler/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudprofiler_v2/google-apis-cloudprofiler_v2.gemspec
+++ b/generated/google-apis-cloudprofiler_v2/google-apis-cloudprofiler_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudresourcemanager_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudresourcemanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/resource-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudresourcemanager_v1/google-apis-cloudresourcemanager_v1.gemspec
+++ b/generated/google-apis-cloudresourcemanager_v1/google-apis-cloudresourcemanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudresourcemanager_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudresourcemanager_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/resource-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudresourcemanager_v1beta1/google-apis-cloudresourcemanager_v1beta1.gemspec
+++ b/generated/google-apis-cloudresourcemanager_v1beta1/google-apis-cloudresourcemanager_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudresourcemanager_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudresourcemanager_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/resource-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudresourcemanager_v2/google-apis-cloudresourcemanager_v2.gemspec
+++ b/generated/google-apis-cloudresourcemanager_v2/google-apis-cloudresourcemanager_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudresourcemanager_v2beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudresourcemanager_v2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/resource-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudresourcemanager_v2beta1/google-apis-cloudresourcemanager_v2beta1.gemspec
+++ b/generated/google-apis-cloudresourcemanager_v2beta1/google-apis-cloudresourcemanager_v2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudresourcemanager_v3/OVERVIEW.md
+++ b/generated/google-apis-cloudresourcemanager_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/resource-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudresourcemanager_v3/google-apis-cloudresourcemanager_v3.gemspec
+++ b/generated/google-apis-cloudresourcemanager_v3/google-apis-cloudresourcemanager_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudscheduler_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudscheduler_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/scheduler/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudscheduler_v1/google-apis-cloudscheduler_v1.gemspec
+++ b/generated/google-apis-cloudscheduler_v1/google-apis-cloudscheduler_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudscheduler_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudscheduler_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/scheduler/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudscheduler_v1beta1/google-apis-cloudscheduler_v1beta1.gemspec
+++ b/generated/google-apis-cloudscheduler_v1beta1/google-apis-cloudscheduler_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudsearch_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudsearch_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/cloud-search
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudsearch_v1/google-apis-cloudsearch_v1.gemspec
+++ b/generated/google-apis-cloudsearch_v1/google-apis-cloudsearch_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudshell_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudshell_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/shell/docs/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudshell_v1/google-apis-cloudshell_v1.gemspec
+++ b/generated/google-apis-cloudshell_v1/google-apis-cloudshell_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudsupport_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudsupport_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/support/docs/apis) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudsupport_v2/google-apis-cloudsupport_v2.gemspec
+++ b/generated/google-apis-cloudsupport_v2/google-apis-cloudsupport_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudsupport_v2beta/OVERVIEW.md
+++ b/generated/google-apis-cloudsupport_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/support/docs/apis) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudsupport_v2beta/google-apis-cloudsupport_v2beta.gemspec
+++ b/generated/google-apis-cloudsupport_v2beta/google-apis-cloudsupport_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtasks_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudtasks_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tasks/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtasks_v2/google-apis-cloudtasks_v2.gemspec
+++ b/generated/google-apis-cloudtasks_v2/google-apis-cloudtasks_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtasks_v2beta2/OVERVIEW.md
+++ b/generated/google-apis-cloudtasks_v2beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tasks/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtasks_v2beta2/google-apis-cloudtasks_v2beta2.gemspec
+++ b/generated/google-apis-cloudtasks_v2beta2/google-apis-cloudtasks_v2beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtasks_v2beta3/OVERVIEW.md
+++ b/generated/google-apis-cloudtasks_v2beta3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tasks/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtasks_v2beta3/google-apis-cloudtasks_v2beta3.gemspec
+++ b/generated/google-apis-cloudtasks_v2beta3/google-apis-cloudtasks_v2beta3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtrace_v1/OVERVIEW.md
+++ b/generated/google-apis-cloudtrace_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/trace/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtrace_v1/google-apis-cloudtrace_v1.gemspec
+++ b/generated/google-apis-cloudtrace_v1/google-apis-cloudtrace_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtrace_v2/OVERVIEW.md
+++ b/generated/google-apis-cloudtrace_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/trace/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtrace_v2/google-apis-cloudtrace_v2.gemspec
+++ b/generated/google-apis-cloudtrace_v2/google-apis-cloudtrace_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-cloudtrace_v2beta1/OVERVIEW.md
+++ b/generated/google-apis-cloudtrace_v2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/trace/) may provide guidanc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-cloudtrace_v2beta1/google-apis-cloudtrace_v2beta1.gemspec
+++ b/generated/google-apis-cloudtrace_v2beta1/google-apis-cloudtrace_v2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-composer_v1/OVERVIEW.md
+++ b/generated/google-apis-composer_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/composer/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-composer_v1/google-apis-composer_v1.gemspec
+++ b/generated/google-apis-composer_v1/google-apis-composer_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-composer_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-composer_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/composer/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-composer_v1beta1/google-apis-composer_v1beta1.gemspec
+++ b/generated/google-apis-composer_v1beta1/google-apis-composer_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-compute_alpha/OVERVIEW.md
+++ b/generated/google-apis-compute_alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-compute_alpha/google-apis-compute_alpha.gemspec
+++ b/generated/google-apis-compute_alpha/google-apis-compute_alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-compute_beta/OVERVIEW.md
+++ b/generated/google-apis-compute_beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-compute_beta/google-apis-compute_beta.gemspec
+++ b/generated/google-apis-compute_beta/google-apis-compute_beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-compute_v1/OVERVIEW.md
+++ b/generated/google-apis-compute_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-compute_v1/google-apis-compute_v1.gemspec
+++ b/generated/google-apis-compute_v1/google-apis-compute_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-config_v1/OVERVIEW.md
+++ b/generated/google-apis-config_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/infrastructure-manager/docs
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-config_v1/google-apis-config_v1.gemspec
+++ b/generated/google-apis-config_v1/google-apis-config_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-connectors_v1/OVERVIEW.md
+++ b/generated/google-apis-connectors_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee/docs/api-platform/co
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-connectors_v1/google-apis-connectors_v1.gemspec
+++ b/generated/google-apis-connectors_v1/google-apis-connectors_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-connectors_v2/OVERVIEW.md
+++ b/generated/google-apis-connectors_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/apigee/docs/api-platform/co
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-connectors_v2/google-apis-connectors_v2.gemspec
+++ b/generated/google-apis-connectors_v2/google-apis-connectors_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-contactcenteraiplatform_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-contactcenteraiplatform_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/solutions/contact-center-ai
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-contactcenteraiplatform_v1alpha1/google-apis-contactcenteraiplatform_v1alpha1.gemspec
+++ b/generated/google-apis-contactcenteraiplatform_v1alpha1/google-apis-contactcenteraiplatform_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-contactcenterinsights_v1/OVERVIEW.md
+++ b/generated/google-apis-contactcenterinsights_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/contact-center/insights/doc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-contactcenterinsights_v1/google-apis-contactcenterinsights_v1.gemspec
+++ b/generated/google-apis-contactcenterinsights_v1/google-apis-contactcenterinsights_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-container_v1/OVERVIEW.md
+++ b/generated/google-apis-container_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/kubernetes-engine/docs/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-container_v1/google-apis-container_v1.gemspec
+++ b/generated/google-apis-container_v1/google-apis-container_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-container_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-container_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/kubernetes-engine/docs/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-container_v1beta1/google-apis-container_v1beta1.gemspec
+++ b/generated/google-apis-container_v1beta1/google-apis-container_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-containeranalysis_v1/OVERVIEW.md
+++ b/generated/google-apis-containeranalysis_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/container-analysis/api/refe
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-containeranalysis_v1/google-apis-containeranalysis_v1.gemspec
+++ b/generated/google-apis-containeranalysis_v1/google-apis-containeranalysis_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-containeranalysis_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-containeranalysis_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/container-analysis/api/refe
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-containeranalysis_v1alpha1/google-apis-containeranalysis_v1alpha1.gemspec
+++ b/generated/google-apis-containeranalysis_v1alpha1/google-apis-containeranalysis_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-containeranalysis_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-containeranalysis_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/container-analysis/api/refe
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-containeranalysis_v1beta1/google-apis-containeranalysis_v1beta1.gemspec
+++ b/generated/google-apis-containeranalysis_v1beta1/google-apis-containeranalysis_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-content_v2_1/OVERVIEW.md
+++ b/generated/google-apis-content_v2_1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/shopping-content/v2/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-content_v2_1/google-apis-content_v2_1.gemspec
+++ b/generated/google-apis-content_v2_1/google-apis-content_v2_1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-contentwarehouse_v1/OVERVIEW.md
+++ b/generated/google-apis-contentwarehouse_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/document-warehouse) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-contentwarehouse_v1/google-apis-contentwarehouse_v1.gemspec
+++ b/generated/google-apis-contentwarehouse_v1/google-apis-contentwarehouse_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-css_v1/OVERVIEW.md
+++ b/generated/google-apis-css_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/comparison-shopping-se
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-css_v1/google-apis-css_v1.gemspec
+++ b/generated/google-apis-css_v1/google-apis-css_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-customsearch_v1/OVERVIEW.md
+++ b/generated/google-apis-customsearch_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/custom-search/v1/intro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-customsearch_v1/google-apis-customsearch_v1.gemspec
+++ b/generated/google-apis-customsearch_v1/google-apis-customsearch_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datacatalog_v1/OVERVIEW.md
+++ b/generated/google-apis-datacatalog_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-catalog/docs/) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datacatalog_v1/google-apis-datacatalog_v1.gemspec
+++ b/generated/google-apis-datacatalog_v1/google-apis-datacatalog_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datacatalog_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-datacatalog_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-catalog/docs/) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datacatalog_v1beta1/google-apis-datacatalog_v1beta1.gemspec
+++ b/generated/google-apis-datacatalog_v1beta1/google-apis-datacatalog_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataflow_v1b3/OVERVIEW.md
+++ b/generated/google-apis-dataflow_v1b3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataflow) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataflow_v1b3/google-apis-dataflow_v1b3.gemspec
+++ b/generated/google-apis-dataflow_v1b3/google-apis-dataflow_v1b3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataform_v1/OVERVIEW.md
+++ b/generated/google-apis-dataform_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataform/docs) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataform_v1/google-apis-dataform_v1.gemspec
+++ b/generated/google-apis-dataform_v1/google-apis-dataform_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataform_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-dataform_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataform/docs) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataform_v1beta1/google-apis-dataform_v1beta1.gemspec
+++ b/generated/google-apis-dataform_v1beta1/google-apis-dataform_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datafusion_v1/OVERVIEW.md
+++ b/generated/google-apis-datafusion_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-fusion/docs) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datafusion_v1/google-apis-datafusion_v1.gemspec
+++ b/generated/google-apis-datafusion_v1/google-apis-datafusion_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datafusion_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-datafusion_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-fusion/docs) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datafusion_v1beta1/google-apis-datafusion_v1beta1.gemspec
+++ b/generated/google-apis-datafusion_v1beta1/google-apis-datafusion_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datalabeling_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-datalabeling_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-labeling/docs/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datalabeling_v1beta1/google-apis-datalabeling_v1beta1.gemspec
+++ b/generated/google-apis-datalabeling_v1beta1/google-apis-datalabeling_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datalineage_v1/OVERVIEW.md
+++ b/generated/google-apis-datalineage_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/data-catalog) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datalineage_v1/google-apis-datalineage_v1.gemspec
+++ b/generated/google-apis-datalineage_v1/google-apis-datalineage_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datamanager_v1/OVERVIEW.md
+++ b/generated/google-apis-datamanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/data-manager) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datamanager_v1/google-apis-datamanager_v1.gemspec
+++ b/generated/google-apis-datamanager_v1/google-apis-datamanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datamigration_v1/OVERVIEW.md
+++ b/generated/google-apis-datamigration_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/database-migration/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datamigration_v1/google-apis-datamigration_v1.gemspec
+++ b/generated/google-apis-datamigration_v1/google-apis-datamigration_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datamigration_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-datamigration_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/database-migration/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datamigration_v1beta1/google-apis-datamigration_v1beta1.gemspec
+++ b/generated/google-apis-datamigration_v1beta1/google-apis-datamigration_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datapipelines_v1/OVERVIEW.md
+++ b/generated/google-apis-datapipelines_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataflow/docs/guides/data-p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datapipelines_v1/google-apis-datapipelines_v1.gemspec
+++ b/generated/google-apis-datapipelines_v1/google-apis-datapipelines_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataplex_v1/OVERVIEW.md
+++ b/generated/google-apis-dataplex_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataplex/docs) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataplex_v1/google-apis-dataplex_v1.gemspec
+++ b/generated/google-apis-dataplex_v1/google-apis-dataplex_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataportability_v1/OVERVIEW.md
+++ b/generated/google-apis-dataportability_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/data-portability) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataportability_v1/google-apis-dataportability_v1.gemspec
+++ b/generated/google-apis-dataportability_v1/google-apis-dataportability_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataportability_v1beta/OVERVIEW.md
+++ b/generated/google-apis-dataportability_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/data-portability) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataportability_v1beta/google-apis-dataportability_v1beta.gemspec
+++ b/generated/google-apis-dataportability_v1beta/google-apis-dataportability_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dataproc_v1/OVERVIEW.md
+++ b/generated/google-apis-dataproc_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataproc/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dataproc_v1/google-apis-dataproc_v1.gemspec
+++ b/generated/google-apis-dataproc_v1/google-apis-dataproc_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datastore_v1/OVERVIEW.md
+++ b/generated/google-apis-datastore_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/datastore/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datastore_v1/google-apis-datastore_v1.gemspec
+++ b/generated/google-apis-datastore_v1/google-apis-datastore_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datastore_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-datastore_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/datastore/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datastore_v1beta1/google-apis-datastore_v1beta1.gemspec
+++ b/generated/google-apis-datastore_v1beta1/google-apis-datastore_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datastore_v1beta3/OVERVIEW.md
+++ b/generated/google-apis-datastore_v1beta3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/datastore/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datastore_v1beta3/google-apis-datastore_v1beta3.gemspec
+++ b/generated/google-apis-datastore_v1beta3/google-apis-datastore_v1beta3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datastream_v1/OVERVIEW.md
+++ b/generated/google-apis-datastream_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/datastream/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datastream_v1/google-apis-datastream_v1.gemspec
+++ b/generated/google-apis-datastream_v1/google-apis-datastream_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-datastream_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-datastream_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/datastream/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-datastream_v1alpha1/google-apis-datastream_v1alpha1.gemspec
+++ b/generated/google-apis-datastream_v1alpha1/google-apis-datastream_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-deploymentmanager_alpha/OVERVIEW.md
+++ b/generated/google-apis-deploymentmanager_alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deployment-manager) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-deploymentmanager_alpha/google-apis-deploymentmanager_alpha.gemspec
+++ b/generated/google-apis-deploymentmanager_alpha/google-apis-deploymentmanager_alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-deploymentmanager_v2/OVERVIEW.md
+++ b/generated/google-apis-deploymentmanager_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deployment-manager) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-deploymentmanager_v2/google-apis-deploymentmanager_v2.gemspec
+++ b/generated/google-apis-deploymentmanager_v2/google-apis-deploymentmanager_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-deploymentmanager_v2beta/OVERVIEW.md
+++ b/generated/google-apis-deploymentmanager_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deployment-manager) may pro
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-deploymentmanager_v2beta/google-apis-deploymentmanager_v2beta.gemspec
+++ b/generated/google-apis-deploymentmanager_v2beta/google-apis-deploymentmanager_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-developerconnect_v1/OVERVIEW.md
+++ b/generated/google-apis-developerconnect_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://cloud.google.com/developer-connect/docs/overv
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-developerconnect_v1/google-apis-developerconnect_v1.gemspec
+++ b/generated/google-apis-developerconnect_v1/google-apis-developerconnect_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-developerknowledge_v1/OVERVIEW.md
+++ b/generated/google-apis-developerknowledge_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/knowledge) may provide
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-developerknowledge_v1/google-apis-developerknowledge_v1.gemspec
+++ b/generated/google-apis-developerknowledge_v1/google-apis-developerknowledge_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-developerknowledge_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-developerknowledge_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/knowledge) may provide
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-developerknowledge_v1alpha/google-apis-developerknowledge_v1alpha.gemspec
+++ b/generated/google-apis-developerknowledge_v1alpha/google-apis-developerknowledge_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dfareporting_v4/OVERVIEW.md
+++ b/generated/google-apis-dfareporting_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/doubleclick-advertiser
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dfareporting_v4/google-apis-dfareporting_v4.gemspec
+++ b/generated/google-apis-dfareporting_v4/google-apis-dfareporting_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dfareporting_v5/OVERVIEW.md
+++ b/generated/google-apis-dfareporting_v5/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/doubleclick-advertiser
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dfareporting_v5/google-apis-dfareporting_v5.gemspec
+++ b/generated/google-apis-dfareporting_v5/google-apis-dfareporting_v5.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dialogflow_v2/OVERVIEW.md
+++ b/generated/google-apis-dialogflow_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dialogflow/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dialogflow_v2/google-apis-dialogflow_v2.gemspec
+++ b/generated/google-apis-dialogflow_v2/google-apis-dialogflow_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dialogflow_v2beta1/OVERVIEW.md
+++ b/generated/google-apis-dialogflow_v2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dialogflow/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dialogflow_v2beta1/google-apis-dialogflow_v2beta1.gemspec
+++ b/generated/google-apis-dialogflow_v2beta1/google-apis-dialogflow_v2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dialogflow_v3/OVERVIEW.md
+++ b/generated/google-apis-dialogflow_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dialogflow/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dialogflow_v3/google-apis-dialogflow_v3.gemspec
+++ b/generated/google-apis-dialogflow_v3/google-apis-dialogflow_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dialogflow_v3beta1/OVERVIEW.md
+++ b/generated/google-apis-dialogflow_v3beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dialogflow/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dialogflow_v3beta1/google-apis-dialogflow_v3beta1.gemspec
+++ b/generated/google-apis-dialogflow_v3beta1/google-apis-dialogflow_v3beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-digitalassetlinks_v1/OVERVIEW.md
+++ b/generated/google-apis-digitalassetlinks_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/digital-asset-links/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-digitalassetlinks_v1/google-apis-digitalassetlinks_v1.gemspec
+++ b/generated/google-apis-digitalassetlinks_v1/google-apis-digitalassetlinks_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-discovery_v1/OVERVIEW.md
+++ b/generated/google-apis-discovery_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/discovery/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-discovery_v1/google-apis-discovery_v1.gemspec
+++ b/generated/google-apis-discovery_v1/google-apis-discovery_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-discoveryengine_v1/OVERVIEW.md
+++ b/generated/google-apis-discoveryengine_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/generative-ai-app-builder/d
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-discoveryengine_v1/google-apis-discoveryengine_v1.gemspec
+++ b/generated/google-apis-discoveryengine_v1/google-apis-discoveryengine_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-discoveryengine_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-discoveryengine_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/generative-ai-app-builder/d
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-discoveryengine_v1alpha/google-apis-discoveryengine_v1alpha.gemspec
+++ b/generated/google-apis-discoveryengine_v1alpha/google-apis-discoveryengine_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-discoveryengine_v1beta/OVERVIEW.md
+++ b/generated/google-apis-discoveryengine_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/generative-ai-app-builder/d
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-discoveryengine_v1beta/google-apis-discoveryengine_v1beta.gemspec
+++ b/generated/google-apis-discoveryengine_v1beta/google-apis-discoveryengine_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-displayvideo_v2/OVERVIEW.md
+++ b/generated/google-apis-displayvideo_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/display-video/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-displayvideo_v2/google-apis-displayvideo_v2.gemspec
+++ b/generated/google-apis-displayvideo_v2/google-apis-displayvideo_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-displayvideo_v3/OVERVIEW.md
+++ b/generated/google-apis-displayvideo_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/display-video/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-displayvideo_v3/google-apis-displayvideo_v3.gemspec
+++ b/generated/google-apis-displayvideo_v3/google-apis-displayvideo_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-displayvideo_v4/OVERVIEW.md
+++ b/generated/google-apis-displayvideo_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/display-video/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-displayvideo_v4/google-apis-displayvideo_v4.gemspec
+++ b/generated/google-apis-displayvideo_v4/google-apis-displayvideo_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dlp_v2/OVERVIEW.md
+++ b/generated/google-apis-dlp_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/sensitive-data-protection/d
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dlp_v2/google-apis-dlp_v2.gemspec
+++ b/generated/google-apis-dlp_v2/google-apis-dlp_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dns_v1/OVERVIEW.md
+++ b/generated/google-apis-dns_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dns/docs) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dns_v1/google-apis-dns_v1.gemspec
+++ b/generated/google-apis-dns_v1/google-apis-dns_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-dns_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-dns_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dns/docs) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-dns_v1beta2/google-apis-dns_v1beta2.gemspec
+++ b/generated/google-apis-dns_v1beta2/google-apis-dns_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-docs_v1/OVERVIEW.md
+++ b/generated/google-apis-docs_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/docs/) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-docs_v1/google-apis-docs_v1.gemspec
+++ b/generated/google-apis-docs_v1/google-apis-docs_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-documentai_v1/OVERVIEW.md
+++ b/generated/google-apis-documentai_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/document-ai/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-documentai_v1/google-apis-documentai_v1.gemspec
+++ b/generated/google-apis-documentai_v1/google-apis-documentai_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-documentai_v1beta3/OVERVIEW.md
+++ b/generated/google-apis-documentai_v1beta3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/document-ai/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-documentai_v1beta3/google-apis-documentai_v1beta3.gemspec
+++ b/generated/google-apis-documentai_v1beta3/google-apis-documentai_v1beta3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-domains_v1/OVERVIEW.md
+++ b/generated/google-apis-domains_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/domains/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-domains_v1/google-apis-domains_v1.gemspec
+++ b/generated/google-apis-domains_v1/google-apis-domains_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-domains_v1alpha2/OVERVIEW.md
+++ b/generated/google-apis-domains_v1alpha2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/domains/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-domains_v1alpha2/google-apis-domains_v1alpha2.gemspec
+++ b/generated/google-apis-domains_v1alpha2/google-apis-domains_v1alpha2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-domains_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-domains_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/domains/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-domains_v1beta1/google-apis-domains_v1beta1.gemspec
+++ b/generated/google-apis-domains_v1beta1/google-apis-domains_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-doubleclickbidmanager_v2/OVERVIEW.md
+++ b/generated/google-apis-doubleclickbidmanager_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/bid-manager/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-doubleclickbidmanager_v2/google-apis-doubleclickbidmanager_v2.gemspec
+++ b/generated/google-apis-doubleclickbidmanager_v2/google-apis-doubleclickbidmanager_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-doubleclicksearch_v2/OVERVIEW.md
+++ b/generated/google-apis-doubleclicksearch_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/search-ads) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-doubleclicksearch_v2/google-apis-doubleclicksearch_v2.gemspec
+++ b/generated/google-apis-doubleclicksearch_v2/google-apis-doubleclicksearch_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-drive_v2/OVERVIEW.md
+++ b/generated/google-apis-drive_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/drive/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-drive_v2/google-apis-drive_v2.gemspec
+++ b/generated/google-apis-drive_v2/google-apis-drive_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-drive_v3/OVERVIEW.md
+++ b/generated/google-apis-drive_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/drive/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-drive_v3/google-apis-drive_v3.gemspec
+++ b/generated/google-apis-drive_v3/google-apis-drive_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-driveactivity_v2/OVERVIEW.md
+++ b/generated/google-apis-driveactivity_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/drive/activi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-driveactivity_v2/google-apis-driveactivity_v2.gemspec
+++ b/generated/google-apis-driveactivity_v2/google-apis-driveactivity_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-drivelabels_v2/OVERVIEW.md
+++ b/generated/google-apis-drivelabels_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/drive/labels
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-drivelabels_v2/google-apis-drivelabels_v2.gemspec
+++ b/generated/google-apis-drivelabels_v2/google-apis-drivelabels_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-drivelabels_v2beta/OVERVIEW.md
+++ b/generated/google-apis-drivelabels_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/drive/labels
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-drivelabels_v2beta/google-apis-drivelabels_v2beta.gemspec
+++ b/generated/google-apis-drivelabels_v2beta/google-apis-drivelabels_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-essentialcontacts_v1/OVERVIEW.md
+++ b/generated/google-apis-essentialcontacts_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/essentialcontacts/docs/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-essentialcontacts_v1/google-apis-essentialcontacts_v1.gemspec
+++ b/generated/google-apis-essentialcontacts_v1/google-apis-essentialcontacts_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-eventarc_v1/OVERVIEW.md
+++ b/generated/google-apis-eventarc_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/eventarc) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-eventarc_v1/google-apis-eventarc_v1.gemspec
+++ b/generated/google-apis-eventarc_v1/google-apis-eventarc_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-factchecktools_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-factchecktools_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/fact-check/tools/api/)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-factchecktools_v1alpha1/google-apis-factchecktools_v1alpha1.gemspec
+++ b/generated/google-apis-factchecktools_v1alpha1/google-apis-factchecktools_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-fcm_v1/OVERVIEW.md
+++ b/generated/google-apis-fcm_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/cloud-messaging) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-fcm_v1/google-apis-fcm_v1.gemspec
+++ b/generated/google-apis-fcm_v1/google-apis-fcm_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-fcmdata_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-fcmdata_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/cloud-messaging) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-fcmdata_v1beta1/google-apis-fcmdata_v1beta1.gemspec
+++ b/generated/google-apis-fcmdata_v1beta1/google-apis-fcmdata_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-file_v1/OVERVIEW.md
+++ b/generated/google-apis-file_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/filestore/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-file_v1/google-apis-file_v1.gemspec
+++ b/generated/google-apis-file_v1/google-apis-file_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-file_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-file_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/filestore/) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-file_v1beta1/google-apis-file_v1beta1.gemspec
+++ b/generated/google-apis-file_v1beta1/google-apis-file_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebase_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-firebase_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com) may provide guidance re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebase_v1beta1/google-apis-firebase_v1beta1.gemspec
+++ b/generated/google-apis-firebase_v1beta1/google-apis-firebase_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseappcheck_v1/OVERVIEW.md
+++ b/generated/google-apis-firebaseappcheck_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/app-check) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseappcheck_v1/google-apis-firebaseappcheck_v1.gemspec
+++ b/generated/google-apis-firebaseappcheck_v1/google-apis-firebaseappcheck_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseappcheck_v1beta/OVERVIEW.md
+++ b/generated/google-apis-firebaseappcheck_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/app-check) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseappcheck_v1beta/google-apis-firebaseappcheck_v1beta.gemspec
+++ b/generated/google-apis-firebaseappcheck_v1beta/google-apis-firebaseappcheck_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseappdistribution_v1/OVERVIEW.md
+++ b/generated/google-apis-firebaseappdistribution_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/products/app-distributio
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseappdistribution_v1/google-apis-firebaseappdistribution_v1.gemspec
+++ b/generated/google-apis-firebaseappdistribution_v1/google-apis-firebaseappdistribution_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseappdistribution_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-firebaseappdistribution_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/products/app-distributio
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseappdistribution_v1alpha/google-apis-firebaseappdistribution_v1alpha.gemspec
+++ b/generated/google-apis-firebaseappdistribution_v1alpha/google-apis-firebaseappdistribution_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseapphosting_v1/OVERVIEW.md
+++ b/generated/google-apis-firebaseapphosting_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/app-hosting) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseapphosting_v1/google-apis-firebaseapphosting_v1.gemspec
+++ b/generated/google-apis-firebaseapphosting_v1/google-apis-firebaseapphosting_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasedatabase_v1beta/OVERVIEW.md
+++ b/generated/google-apis-firebasedatabase_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/reference/rest/data
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasedatabase_v1beta/google-apis-firebasedatabase_v1beta.gemspec
+++ b/generated/google-apis-firebasedatabase_v1beta/google-apis-firebasedatabase_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasedataconnect_v1/OVERVIEW.md
+++ b/generated/google-apis-firebasedataconnect_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/data-connect) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasedataconnect_v1/google-apis-firebasedataconnect_v1.gemspec
+++ b/generated/google-apis-firebasedataconnect_v1/google-apis-firebasedataconnect_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasedataconnect_v1beta/OVERVIEW.md
+++ b/generated/google-apis-firebasedataconnect_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/data-connect) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasedataconnect_v1beta/google-apis-firebasedataconnect_v1beta.gemspec
+++ b/generated/google-apis-firebasedataconnect_v1beta/google-apis-firebasedataconnect_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasedynamiclinks_v1/OVERVIEW.md
+++ b/generated/google-apis-firebasedynamiclinks_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/dynamic-links/) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasedynamiclinks_v1/google-apis-firebasedynamiclinks_v1.gemspec
+++ b/generated/google-apis-firebasedynamiclinks_v1/google-apis-firebasedynamiclinks_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasehosting_v1/OVERVIEW.md
+++ b/generated/google-apis-firebasehosting_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/hosting/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasehosting_v1/google-apis-firebasehosting_v1.gemspec
+++ b/generated/google-apis-firebasehosting_v1/google-apis-firebasehosting_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasehosting_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-firebasehosting_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/hosting/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasehosting_v1beta1/google-apis-firebasehosting_v1beta1.gemspec
+++ b/generated/google-apis-firebasehosting_v1beta1/google-apis-firebasehosting_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseml_v1/OVERVIEW.md
+++ b/generated/google-apis-firebaseml_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com) may provide guidance re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseml_v1/google-apis-firebaseml_v1.gemspec
+++ b/generated/google-apis-firebaseml_v1/google-apis-firebaseml_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseml_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-firebaseml_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com) may provide guidance re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseml_v1beta2/google-apis-firebaseml_v1beta2.gemspec
+++ b/generated/google-apis-firebaseml_v1beta2/google-apis-firebaseml_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaseml_v2beta/OVERVIEW.md
+++ b/generated/google-apis-firebaseml_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com) may provide guidance re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaseml_v2beta/google-apis-firebaseml_v2beta.gemspec
+++ b/generated/google-apis-firebaseml_v2beta/google-apis-firebaseml_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebaserules_v1/OVERVIEW.md
+++ b/generated/google-apis-firebaserules_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/storage/security) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebaserules_v1/google-apis-firebaserules_v1.gemspec
+++ b/generated/google-apis-firebaserules_v1/google-apis-firebaserules_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firebasestorage_v1beta/OVERVIEW.md
+++ b/generated/google-apis-firebasestorage_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/storage) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firebasestorage_v1beta/google-apis-firebasestorage_v1beta.gemspec
+++ b/generated/google-apis-firebasestorage_v1beta/google-apis-firebasestorage_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firestore_v1/OVERVIEW.md
+++ b/generated/google-apis-firestore_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/firestore) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firestore_v1/google-apis-firestore_v1.gemspec
+++ b/generated/google-apis-firestore_v1/google-apis-firestore_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firestore_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-firestore_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/firestore) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firestore_v1beta1/google-apis-firestore_v1beta1.gemspec
+++ b/generated/google-apis-firestore_v1beta1/google-apis-firestore_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-firestore_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-firestore_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/firestore) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-firestore_v1beta2/google-apis-firestore_v1beta2.gemspec
+++ b/generated/google-apis-firestore_v1beta2/google-apis-firestore_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-fitness_v1/OVERVIEW.md
+++ b/generated/google-apis-fitness_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/fit/rest/v1/get-starte
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-fitness_v1/google-apis-fitness_v1.gemspec
+++ b/generated/google-apis-fitness_v1/google-apis-fitness_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-forms_v1/OVERVIEW.md
+++ b/generated/google-apis-forms_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/forms/api) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-forms_v1/google-apis-forms_v1.gemspec
+++ b/generated/google-apis-forms_v1/google-apis-forms_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-games_configuration_v1configuration/OVERVIEW.md
+++ b/generated/google-apis-games_configuration_v1configuration/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/games/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-games_configuration_v1configuration/google-apis-games_configuration_v1configuration.gemspec
+++ b/generated/google-apis-games_configuration_v1configuration/google-apis-games_configuration_v1configuration.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-games_management_v1management/OVERVIEW.md
+++ b/generated/google-apis-games_management_v1management/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/games/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-games_management_v1management/google-apis-games_management_v1management.gemspec
+++ b/generated/google-apis-games_management_v1management/google-apis-games_management_v1management.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-games_v1/OVERVIEW.md
+++ b/generated/google-apis-games_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/games/) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-games_v1/google-apis-games_v1.gemspec
+++ b/generated/google-apis-games_v1/google-apis-games_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkebackup_v1/OVERVIEW.md
+++ b/generated/google-apis-gkebackup_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/kubernetes-engine/docs/add-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkebackup_v1/google-apis-gkebackup_v1.gemspec
+++ b/generated/google-apis-gkebackup_v1/google-apis-gkebackup_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v1/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v1/google-apis-gkehub_v1.gemspec
+++ b/generated/google-apis-gkehub_v1/google-apis-gkehub_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v1alpha/google-apis-gkehub_v1alpha.gemspec
+++ b/generated/google-apis-gkehub_v1alpha/google-apis-gkehub_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v1beta/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v1beta/google-apis-gkehub_v1beta.gemspec
+++ b/generated/google-apis-gkehub_v1beta/google-apis-gkehub_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v1beta1/google-apis-gkehub_v1beta1.gemspec
+++ b/generated/google-apis-gkehub_v1beta1/google-apis-gkehub_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v2/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v2/google-apis-gkehub_v2.gemspec
+++ b/generated/google-apis-gkehub_v2/google-apis-gkehub_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkehub_v2alpha/OVERVIEW.md
+++ b/generated/google-apis-gkehub_v2alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/multicluster-managem
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkehub_v2alpha/google-apis-gkehub_v2alpha.gemspec
+++ b/generated/google-apis-gkehub_v2alpha/google-apis-gkehub_v2alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gkeonprem_v1/OVERVIEW.md
+++ b/generated/google-apis-gkeonprem_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/anthos/clusters/docs/on-pre
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gkeonprem_v1/google-apis-gkeonprem_v1.gemspec
+++ b/generated/google-apis-gkeonprem_v1/google-apis-gkeonprem_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gmail_v1/OVERVIEW.md
+++ b/generated/google-apis-gmail_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/gmail/api/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gmail_v1/google-apis-gmail_v1.gemspec
+++ b/generated/google-apis-gmail_v1/google-apis-gmail_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gmailpostmastertools_v1/OVERVIEW.md
+++ b/generated/google-apis-gmailpostmastertools_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/gmail/postma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gmailpostmastertools_v1/google-apis-gmailpostmastertools_v1.gemspec
+++ b/generated/google-apis-gmailpostmastertools_v1/google-apis-gmailpostmastertools_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gmailpostmastertools_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-gmailpostmastertools_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/gmail/postma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gmailpostmastertools_v1beta1/google-apis-gmailpostmastertools_v1beta1.gemspec
+++ b/generated/google-apis-gmailpostmastertools_v1beta1/google-apis-gmailpostmastertools_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-gmailpostmastertools_v2/OVERVIEW.md
+++ b/generated/google-apis-gmailpostmastertools_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/gmail/postma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-gmailpostmastertools_v2/google-apis-gmailpostmastertools_v2.gemspec
+++ b/generated/google-apis-gmailpostmastertools_v2/google-apis-gmailpostmastertools_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-groupsmigration_v1/OVERVIEW.md
+++ b/generated/google-apis-groupsmigration_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/google-apps/groups-mig
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-groupsmigration_v1/google-apis-groupsmigration_v1.gemspec
+++ b/generated/google-apis-groupsmigration_v1/google-apis-groupsmigration_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-groupssettings_v1/OVERVIEW.md
+++ b/generated/google-apis-groupssettings_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/google-apps/groups-set
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-groupssettings_v1/google-apis-groupssettings_v1.gemspec
+++ b/generated/google-apis-groupssettings_v1/google-apis-groupssettings_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-health_v4/OVERVIEW.md
+++ b/generated/google-apis-health_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/health) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-health_v4/google-apis-health_v4.gemspec
+++ b/generated/google-apis-health_v4/google-apis-health_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-healthcare_v1/OVERVIEW.md
+++ b/generated/google-apis-healthcare_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/healthcare) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-healthcare_v1/google-apis-healthcare_v1.gemspec
+++ b/generated/google-apis-healthcare_v1/google-apis-healthcare_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-healthcare_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-healthcare_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/healthcare) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-healthcare_v1beta1/google-apis-healthcare_v1beta1.gemspec
+++ b/generated/google-apis-healthcare_v1beta1/google-apis-healthcare_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-homegraph_v1/OVERVIEW.md
+++ b/generated/google-apis-homegraph_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.home.google.com/cloud-to-cloud/ge
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-homegraph_v1/google-apis-homegraph_v1.gemspec
+++ b/generated/google-apis-homegraph_v1/google-apis-homegraph_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-hypercomputecluster_v1/OVERVIEW.md
+++ b/generated/google-apis-hypercomputecluster_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/cluster-director/docs)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-hypercomputecluster_v1/google-apis-hypercomputecluster_v1.gemspec
+++ b/generated/google-apis-hypercomputecluster_v1/google-apis-hypercomputecluster_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iam_v1/OVERVIEW.md
+++ b/generated/google-apis-iam_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iam_v1/google-apis-iam_v1.gemspec
+++ b/generated/google-apis-iam_v1/google-apis-iam_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iam_v2/OVERVIEW.md
+++ b/generated/google-apis-iam_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iam_v2/google-apis-iam_v2.gemspec
+++ b/generated/google-apis-iam_v2/google-apis-iam_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iam_v2beta/OVERVIEW.md
+++ b/generated/google-apis-iam_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iam_v2beta/google-apis-iam_v2beta.gemspec
+++ b/generated/google-apis-iam_v2beta/google-apis-iam_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iamcredentials_v1/OVERVIEW.md
+++ b/generated/google-apis-iamcredentials_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/docs/creating-short-liv
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iamcredentials_v1/google-apis-iamcredentials_v1.gemspec
+++ b/generated/google-apis-iamcredentials_v1/google-apis-iamcredentials_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iap_v1/OVERVIEW.md
+++ b/generated/google-apis-iap_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iap) may provide guidance r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iap_v1/google-apis-iap_v1.gemspec
+++ b/generated/google-apis-iap_v1/google-apis-iap_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-iap_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-iap_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iap) may provide guidance r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-iap_v1beta1/google-apis-iap_v1beta1.gemspec
+++ b/generated/google-apis-iap_v1beta1/google-apis-iap_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-identitytoolkit_v1/OVERVIEW.md
+++ b/generated/google-apis-identitytoolkit_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/identity-platform) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-identitytoolkit_v1/google-apis-identitytoolkit_v1.gemspec
+++ b/generated/google-apis-identitytoolkit_v1/google-apis-identitytoolkit_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-identitytoolkit_v2/OVERVIEW.md
+++ b/generated/google-apis-identitytoolkit_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/identity-platform) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-identitytoolkit_v2/google-apis-identitytoolkit_v2.gemspec
+++ b/generated/google-apis-identitytoolkit_v2/google-apis-identitytoolkit_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-identitytoolkit_v3/OVERVIEW.md
+++ b/generated/google-apis-identitytoolkit_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/identity-toolkit/v3/) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-identitytoolkit_v3/google-apis-identitytoolkit_v3.gemspec
+++ b/generated/google-apis-identitytoolkit_v3/google-apis-identitytoolkit_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-ids_v1/OVERVIEW.md
+++ b/generated/google-apis-ids_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-ids_v1/google-apis-ids_v1.gemspec
+++ b/generated/google-apis-ids_v1/google-apis-ids_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-indexing_v3/OVERVIEW.md
+++ b/generated/google-apis-indexing_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/search/apis/indexing-a
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-indexing_v3/google-apis-indexing_v3.gemspec
+++ b/generated/google-apis-indexing_v3/google-apis-indexing_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-integrations_v1/OVERVIEW.md
+++ b/generated/google-apis-integrations_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/application-integration) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-integrations_v1/google-apis-integrations_v1.gemspec
+++ b/generated/google-apis-integrations_v1/google-apis-integrations_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-jobs_v3/OVERVIEW.md
+++ b/generated/google-apis-jobs_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/talent-solution/job-search/
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-jobs_v3/google-apis-jobs_v3.gemspec
+++ b/generated/google-apis-jobs_v3/google-apis-jobs_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-jobs_v3p1beta1/OVERVIEW.md
+++ b/generated/google-apis-jobs_v3p1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/talent-solution/job-search/
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-jobs_v3p1beta1/google-apis-jobs_v3p1beta1.gemspec
+++ b/generated/google-apis-jobs_v3p1beta1/google-apis-jobs_v3p1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-jobs_v4/OVERVIEW.md
+++ b/generated/google-apis-jobs_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/talent-solution/job-search/
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-jobs_v4/google-apis-jobs_v4.gemspec
+++ b/generated/google-apis-jobs_v4/google-apis-jobs_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-keep_v1/OVERVIEW.md
+++ b/generated/google-apis-keep_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/keep/api) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-keep_v1/google-apis-keep_v1.gemspec
+++ b/generated/google-apis-keep_v1/google-apis-keep_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-kgsearch_v1/OVERVIEW.md
+++ b/generated/google-apis-kgsearch_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/knowledge-graph/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-kgsearch_v1/google-apis-kgsearch_v1.gemspec
+++ b/generated/google-apis-kgsearch_v1/google-apis-kgsearch_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-kmsinventory_v1/OVERVIEW.md
+++ b/generated/google-apis-kmsinventory_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/kms/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-kmsinventory_v1/google-apis-kmsinventory_v1.gemspec
+++ b/generated/google-apis-kmsinventory_v1/google-apis-kmsinventory_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-language_v1/OVERVIEW.md
+++ b/generated/google-apis-language_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/natural-language/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-language_v1/google-apis-language_v1.gemspec
+++ b/generated/google-apis-language_v1/google-apis-language_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-language_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-language_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/natural-language/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-language_v1beta2/google-apis-language_v1beta2.gemspec
+++ b/generated/google-apis-language_v1beta2/google-apis-language_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-language_v2/OVERVIEW.md
+++ b/generated/google-apis-language_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/natural-language/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-language_v2/google-apis-language_v2.gemspec
+++ b/generated/google-apis-language_v2/google-apis-language_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-libraryagent_v1/OVERVIEW.md
+++ b/generated/google-apis-libraryagent_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/docs/quota) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-libraryagent_v1/google-apis-libraryagent_v1.gemspec
+++ b/generated/google-apis-libraryagent_v1/google-apis-libraryagent_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-licensing_v1/OVERVIEW.md
+++ b/generated/google-apis-licensing_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/admin/licens
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-licensing_v1/google-apis-licensing_v1.gemspec
+++ b/generated/google-apis-licensing_v1/google-apis-licensing_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-lifesciences_v2beta/OVERVIEW.md
+++ b/generated/google-apis-lifesciences_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/life-sciences) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-lifesciences_v2beta/google-apis-lifesciences_v2beta.gemspec
+++ b/generated/google-apis-lifesciences_v2beta/google-apis-lifesciences_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-localservices_v1/OVERVIEW.md
+++ b/generated/google-apis-localservices_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://ads.google.com/local-services-ads/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-localservices_v1/google-apis-localservices_v1.gemspec
+++ b/generated/google-apis-localservices_v1/google-apis-localservices_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-logging_v2/OVERVIEW.md
+++ b/generated/google-apis-logging_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/logging/docs/) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-logging_v2/google-apis-logging_v2.gemspec
+++ b/generated/google-apis-logging_v2/google-apis-logging_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-looker_v1/OVERVIEW.md
+++ b/generated/google-apis-looker_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/looker/docs/reference/rest/
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-looker_v1/google-apis-looker_v1.gemspec
+++ b/generated/google-apis-looker_v1/google-apis-looker_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-managedidentities_v1/OVERVIEW.md
+++ b/generated/google-apis-managedidentities_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/managed-microsoft-ad/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-managedidentities_v1/google-apis-managedidentities_v1.gemspec
+++ b/generated/google-apis-managedidentities_v1/google-apis-managedidentities_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-managedidentities_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-managedidentities_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/managed-microsoft-ad/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-managedidentities_v1alpha1/google-apis-managedidentities_v1alpha1.gemspec
+++ b/generated/google-apis-managedidentities_v1alpha1/google-apis-managedidentities_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-managedidentities_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-managedidentities_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/managed-microsoft-ad/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-managedidentities_v1beta1/google-apis-managedidentities_v1beta1.gemspec
+++ b/generated/google-apis-managedidentities_v1beta1/google-apis-managedidentities_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-managedkafka_v1/OVERVIEW.md
+++ b/generated/google-apis-managedkafka_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/managed-service-for-apache-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-managedkafka_v1/google-apis-managedkafka_v1.gemspec
+++ b/generated/google-apis-managedkafka_v1/google-apis-managedkafka_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-manufacturers_v1/OVERVIEW.md
+++ b/generated/google-apis-manufacturers_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/manufacturers/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-manufacturers_v1/google-apis-manufacturers_v1.gemspec
+++ b/generated/google-apis-manufacturers_v1/google-apis-manufacturers_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-marketingplatformadmin_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-marketingplatformadmin_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/analytics/devguides/co
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-marketingplatformadmin_v1alpha/google-apis-marketingplatformadmin_v1alpha.gemspec
+++ b/generated/google-apis-marketingplatformadmin_v1alpha/google-apis-marketingplatformadmin_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-meet_v2/OVERVIEW.md
+++ b/generated/google-apis-meet_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/meet/api) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-meet_v2/google-apis-meet_v2.gemspec
+++ b/generated/google-apis-meet_v2/google-apis-meet_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-memcache_v1/OVERVIEW.md
+++ b/generated/google-apis-memcache_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/memorystore/) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-memcache_v1/google-apis-memcache_v1.gemspec
+++ b/generated/google-apis-memcache_v1/google-apis-memcache_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-memcache_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-memcache_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/memorystore/) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-memcache_v1beta2/google-apis-memcache_v1beta2.gemspec
+++ b/generated/google-apis-memcache_v1beta2/google-apis-memcache_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_accounts_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_accounts_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_accounts_v1beta/google-apis-merchantapi_accounts_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_accounts_v1beta/google-apis-merchantapi_accounts_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_conversions_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_conversions_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_conversions_v1beta/google-apis-merchantapi_conversions_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_conversions_v1beta/google-apis-merchantapi_conversions_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_datasources_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_datasources_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_datasources_v1beta/google-apis-merchantapi_datasources_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_datasources_v1beta/google-apis-merchantapi_datasources_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_inventories_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_inventories_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_inventories_v1beta/google-apis-merchantapi_inventories_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_inventories_v1beta/google-apis-merchantapi_inventories_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_lfp_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_lfp_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_lfp_v1beta/google-apis-merchantapi_lfp_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_lfp_v1beta/google-apis-merchantapi_lfp_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_notifications_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_notifications_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_notifications_v1beta/google-apis-merchantapi_notifications_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_notifications_v1beta/google-apis-merchantapi_notifications_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_products_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_products_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_products_v1beta/google-apis-merchantapi_products_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_products_v1beta/google-apis-merchantapi_products_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_promotions_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_promotions_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_promotions_v1beta/google-apis-merchantapi_promotions_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_promotions_v1beta/google-apis-merchantapi_promotions_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_quota_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_quota_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_quota_v1beta/google-apis-merchantapi_quota_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_quota_v1beta/google-apis-merchantapi_quota_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_reports_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_reports_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_reports_v1beta/google-apis-merchantapi_reports_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_reports_v1beta/google-apis-merchantapi_reports_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-merchantapi_reviews_v1beta/OVERVIEW.md
+++ b/generated/google-apis-merchantapi_reviews_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/merchant/api) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-merchantapi_reviews_v1beta/google-apis-merchantapi_reviews_v1beta.gemspec
+++ b/generated/google-apis-merchantapi_reviews_v1beta/google-apis-merchantapi_reviews_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-metastore_v1/OVERVIEW.md
+++ b/generated/google-apis-metastore_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataproc-metastore/docs) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-metastore_v1/google-apis-metastore_v1.gemspec
+++ b/generated/google-apis-metastore_v1/google-apis-metastore_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-metastore_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-metastore_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataproc-metastore/docs) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-metastore_v1alpha/google-apis-metastore_v1alpha.gemspec
+++ b/generated/google-apis-metastore_v1alpha/google-apis-metastore_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-metastore_v1beta/OVERVIEW.md
+++ b/generated/google-apis-metastore_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/dataproc-metastore/docs) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-metastore_v1beta/google-apis-metastore_v1beta.gemspec
+++ b/generated/google-apis-metastore_v1beta/google-apis-metastore_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-migrationcenter_v1/OVERVIEW.md
+++ b/generated/google-apis-migrationcenter_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/migration-center) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-migrationcenter_v1/google-apis-migrationcenter_v1.gemspec
+++ b/generated/google-apis-migrationcenter_v1/google-apis-migrationcenter_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-migrationcenter_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-migrationcenter_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/migration-center) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-migrationcenter_v1alpha1/google-apis-migrationcenter_v1alpha1.gemspec
+++ b/generated/google-apis-migrationcenter_v1alpha1/google-apis-migrationcenter_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-ml_v1/OVERVIEW.md
+++ b/generated/google-apis-ml_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/ml/) may provide guidance r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-ml_v1/google-apis-ml_v1.gemspec
+++ b/generated/google-apis-ml_v1/google-apis-ml_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-monitoring_v1/OVERVIEW.md
+++ b/generated/google-apis-monitoring_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/monitoring/api/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-monitoring_v1/google-apis-monitoring_v1.gemspec
+++ b/generated/google-apis-monitoring_v1/google-apis-monitoring_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-monitoring_v3/OVERVIEW.md
+++ b/generated/google-apis-monitoring_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/monitoring/api/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-monitoring_v3/google-apis-monitoring_v3.gemspec
+++ b/generated/google-apis-monitoring_v3/google-apis-monitoring_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessaccountmanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessaccountmanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessaccountmanagement_v1/google-apis-mybusinessaccountmanagement_v1.gemspec
+++ b/generated/google-apis-mybusinessaccountmanagement_v1/google-apis-mybusinessaccountmanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessbusinessinformation_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessbusinessinformation_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessbusinessinformation_v1/google-apis-mybusinessbusinessinformation_v1.gemspec
+++ b/generated/google-apis-mybusinessbusinessinformation_v1/google-apis-mybusinessbusinessinformation_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinesslodging_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinesslodging_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinesslodging_v1/google-apis-mybusinesslodging_v1.gemspec
+++ b/generated/google-apis-mybusinesslodging_v1/google-apis-mybusinesslodging_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessnotifications_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessnotifications_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessnotifications_v1/google-apis-mybusinessnotifications_v1.gemspec
+++ b/generated/google-apis-mybusinessnotifications_v1/google-apis-mybusinessnotifications_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessplaceactions_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessplaceactions_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessplaceactions_v1/google-apis-mybusinessplaceactions_v1.gemspec
+++ b/generated/google-apis-mybusinessplaceactions_v1/google-apis-mybusinessplaceactions_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessqanda_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessqanda_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessqanda_v1/google-apis-mybusinessqanda_v1.gemspec
+++ b/generated/google-apis-mybusinessqanda_v1/google-apis-mybusinessqanda_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-mybusinessverifications_v1/OVERVIEW.md
+++ b/generated/google-apis-mybusinessverifications_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/my-business/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-mybusinessverifications_v1/google-apis-mybusinessverifications_v1.gemspec
+++ b/generated/google-apis-mybusinessverifications_v1/google-apis-mybusinessverifications_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-netapp_v1/OVERVIEW.md
+++ b/generated/google-apis-netapp_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/netapp/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-netapp_v1/google-apis-netapp_v1.gemspec
+++ b/generated/google-apis-netapp_v1/google-apis-netapp_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkconnectivity_v1/OVERVIEW.md
+++ b/generated/google-apis-networkconnectivity_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/network-connectivity/docs/r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkconnectivity_v1/google-apis-networkconnectivity_v1.gemspec
+++ b/generated/google-apis-networkconnectivity_v1/google-apis-networkconnectivity_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkconnectivity_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-networkconnectivity_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/network-connectivity/docs/r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkconnectivity_v1alpha1/google-apis-networkconnectivity_v1alpha1.gemspec
+++ b/generated/google-apis-networkconnectivity_v1alpha1/google-apis-networkconnectivity_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkmanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-networkmanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkmanagement_v1/google-apis-networkmanagement_v1.gemspec
+++ b/generated/google-apis-networkmanagement_v1/google-apis-networkmanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkmanagement_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-networkmanagement_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkmanagement_v1beta1/google-apis-networkmanagement_v1beta1.gemspec
+++ b/generated/google-apis-networkmanagement_v1beta1/google-apis-networkmanagement_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networksecurity_v1/OVERVIEW.md
+++ b/generated/google-apis-networksecurity_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/networking) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networksecurity_v1/google-apis-networksecurity_v1.gemspec
+++ b/generated/google-apis-networksecurity_v1/google-apis-networksecurity_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networksecurity_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-networksecurity_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/networking) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networksecurity_v1beta1/google-apis-networksecurity_v1beta1.gemspec
+++ b/generated/google-apis-networksecurity_v1beta1/google-apis-networksecurity_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkservices_v1/OVERVIEW.md
+++ b/generated/google-apis-networkservices_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/networking) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkservices_v1/google-apis-networkservices_v1.gemspec
+++ b/generated/google-apis-networkservices_v1/google-apis-networkservices_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-networkservices_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-networkservices_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/networking) may provide gui
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-networkservices_v1beta1/google-apis-networkservices_v1beta1.gemspec
+++ b/generated/google-apis-networkservices_v1beta1/google-apis-networkservices_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-notebooks_v1/OVERVIEW.md
+++ b/generated/google-apis-notebooks_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/notebooks/docs/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-notebooks_v1/google-apis-notebooks_v1.gemspec
+++ b/generated/google-apis-notebooks_v1/google-apis-notebooks_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-notebooks_v2/OVERVIEW.md
+++ b/generated/google-apis-notebooks_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/notebooks/docs/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-notebooks_v2/google-apis-notebooks_v2.gemspec
+++ b/generated/google-apis-notebooks_v2/google-apis-notebooks_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-oauth2_v2/OVERVIEW.md
+++ b/generated/google-apis-oauth2_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/identity/protocols/oau
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-oauth2_v2/google-apis-oauth2_v2.gemspec
+++ b/generated/google-apis-oauth2_v2/google-apis-oauth2_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-observability_v1/OVERVIEW.md
+++ b/generated/google-apis-observability_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/stackdriver/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-observability_v1/google-apis-observability_v1.gemspec
+++ b/generated/google-apis-observability_v1/google-apis-observability_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-ondemandscanning_v1/OVERVIEW.md
+++ b/generated/google-apis-ondemandscanning_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/container-analysis/docs/on-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-ondemandscanning_v1/google-apis-ondemandscanning_v1.gemspec
+++ b/generated/google-apis-ondemandscanning_v1/google-apis-ondemandscanning_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-ondemandscanning_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-ondemandscanning_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/container-analysis/docs/on-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-ondemandscanning_v1beta1/google-apis-ondemandscanning_v1beta1.gemspec
+++ b/generated/google-apis-ondemandscanning_v1beta1/google-apis-ondemandscanning_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-oracledatabase_v1/OVERVIEW.md
+++ b/generated/google-apis-oracledatabase_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/oracle/database/docs) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-oracledatabase_v1/google-apis-oracledatabase_v1.gemspec
+++ b/generated/google-apis-oracledatabase_v1/google-apis-oracledatabase_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-orgpolicy_v2/OVERVIEW.md
+++ b/generated/google-apis-orgpolicy_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/orgpolicy/docs/reference/re
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-orgpolicy_v2/google-apis-orgpolicy_v2.gemspec
+++ b/generated/google-apis-orgpolicy_v2/google-apis-orgpolicy_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-osconfig_v1/OVERVIEW.md
+++ b/generated/google-apis-osconfig_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/osconfig/rest)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-osconfig_v1/google-apis-osconfig_v1.gemspec
+++ b/generated/google-apis-osconfig_v1/google-apis-osconfig_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-osconfig_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-osconfig_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/osconfig/rest)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-osconfig_v1alpha/google-apis-osconfig_v1alpha.gemspec
+++ b/generated/google-apis-osconfig_v1alpha/google-apis-osconfig_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-osconfig_v1beta/OVERVIEW.md
+++ b/generated/google-apis-osconfig_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/osconfig/rest)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-osconfig_v1beta/google-apis-osconfig_v1beta.gemspec
+++ b/generated/google-apis-osconfig_v1beta/google-apis-osconfig_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-osconfig_v2/OVERVIEW.md
+++ b/generated/google-apis-osconfig_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/osconfig/rest)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-osconfig_v2/google-apis-osconfig_v2.gemspec
+++ b/generated/google-apis-osconfig_v2/google-apis-osconfig_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-oslogin_v1/OVERVIEW.md
+++ b/generated/google-apis-oslogin_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/oslogin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-oslogin_v1/google-apis-oslogin_v1.gemspec
+++ b/generated/google-apis-oslogin_v1/google-apis-oslogin_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-oslogin_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-oslogin_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/oslogin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-oslogin_v1alpha/google-apis-oslogin_v1alpha.gemspec
+++ b/generated/google-apis-oslogin_v1alpha/google-apis-oslogin_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-oslogin_v1beta/OVERVIEW.md
+++ b/generated/google-apis-oslogin_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/compute/docs/oslogin/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-oslogin_v1beta/google-apis-oslogin_v1beta.gemspec
+++ b/generated/google-apis-oslogin_v1beta/google-apis-oslogin_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pagespeedonline_v5/OVERVIEW.md
+++ b/generated/google-apis-pagespeedonline_v5/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/speed/docs/insights/v5
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pagespeedonline_v5/google-apis-pagespeedonline_v5.gemspec
+++ b/generated/google-apis-pagespeedonline_v5/google-apis-pagespeedonline_v5.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-parallelstore_v1/OVERVIEW.md
+++ b/generated/google-apis-parallelstore_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/parallelstore) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-parallelstore_v1/google-apis-parallelstore_v1.gemspec
+++ b/generated/google-apis-parallelstore_v1/google-apis-parallelstore_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-parametermanager_v1/OVERVIEW.md
+++ b/generated/google-apis-parametermanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/secret-manager/parameter-ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-parametermanager_v1/google-apis-parametermanager_v1.gemspec
+++ b/generated/google-apis-parametermanager_v1/google-apis-parametermanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-paymentsresellersubscription_v1/OVERVIEW.md
+++ b/generated/google-apis-paymentsresellersubscription_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/payments/reseller/subs
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-paymentsresellersubscription_v1/google-apis-paymentsresellersubscription_v1.gemspec
+++ b/generated/google-apis-paymentsresellersubscription_v1/google-apis-paymentsresellersubscription_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-people_v1/OVERVIEW.md
+++ b/generated/google-apis-people_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/people/) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-people_v1/google-apis-people_v1.gemspec
+++ b/generated/google-apis-people_v1/google-apis-people_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-places_v1/OVERVIEW.md
+++ b/generated/google-apis-places_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://mapsplatform.google.com/maps-products/#place
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-places_v1/google-apis-places_v1.gemspec
+++ b/generated/google-apis-places_v1/google-apis-places_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-playcustomapp_v1/OVERVIEW.md
+++ b/generated/google-apis-playcustomapp_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/android/work/play/cust
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-playcustomapp_v1/google-apis-playcustomapp_v1.gemspec
+++ b/generated/google-apis-playcustomapp_v1/google-apis-playcustomapp_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-playdeveloperreporting_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-playdeveloperreporting_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/play/developer/reporti
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-playdeveloperreporting_v1alpha1/google-apis-playdeveloperreporting_v1alpha1.gemspec
+++ b/generated/google-apis-playdeveloperreporting_v1alpha1/google-apis-playdeveloperreporting_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-playdeveloperreporting_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-playdeveloperreporting_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/play/developer/reporti
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-playdeveloperreporting_v1beta1/google-apis-playdeveloperreporting_v1beta1.gemspec
+++ b/generated/google-apis-playdeveloperreporting_v1beta1/google-apis-playdeveloperreporting_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-playgrouping_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-playgrouping_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/playgrouping/) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-playgrouping_v1alpha1/google-apis-playgrouping_v1alpha1.gemspec
+++ b/generated/google-apis-playgrouping_v1alpha1/google-apis-playgrouping_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-playintegrity_v1/OVERVIEW.md
+++ b/generated/google-apis-playintegrity_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developer.android.com/google/play/integrity)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-playintegrity_v1/google-apis-playintegrity_v1.gemspec
+++ b/generated/google-apis-playintegrity_v1/google-apis-playintegrity_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policyanalyzer_v1/OVERVIEW.md
+++ b/generated/google-apis-policyanalyzer_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://www.google.com) may provide guidance regardi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policyanalyzer_v1/google-apis-policyanalyzer_v1.gemspec
+++ b/generated/google-apis-policyanalyzer_v1/google-apis-policyanalyzer_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policyanalyzer_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-policyanalyzer_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://www.google.com) may provide guidance regardi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policyanalyzer_v1beta1/google-apis-policyanalyzer_v1beta1.gemspec
+++ b/generated/google-apis-policyanalyzer_v1beta1/google-apis-policyanalyzer_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policysimulator_v1/OVERVIEW.md
+++ b/generated/google-apis-policysimulator_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/docs/simulating-access)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policysimulator_v1/google-apis-policysimulator_v1.gemspec
+++ b/generated/google-apis-policysimulator_v1/google-apis-policysimulator_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policysimulator_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-policysimulator_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/docs/simulating-access)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policysimulator_v1alpha/google-apis-policysimulator_v1alpha.gemspec
+++ b/generated/google-apis-policysimulator_v1alpha/google-apis-policysimulator_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policysimulator_v1beta/OVERVIEW.md
+++ b/generated/google-apis-policysimulator_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/docs/simulating-access)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policysimulator_v1beta/google-apis-policysimulator_v1beta.gemspec
+++ b/generated/google-apis-policysimulator_v1beta/google-apis-policysimulator_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policytroubleshooter_v1/OVERVIEW.md
+++ b/generated/google-apis-policytroubleshooter_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policytroubleshooter_v1/google-apis-policytroubleshooter_v1.gemspec
+++ b/generated/google-apis-policytroubleshooter_v1/google-apis-policytroubleshooter_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policytroubleshooter_v1beta/OVERVIEW.md
+++ b/generated/google-apis-policytroubleshooter_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policytroubleshooter_v1beta/google-apis-policytroubleshooter_v1beta.gemspec
+++ b/generated/google-apis-policytroubleshooter_v1beta/google-apis-policytroubleshooter_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-policytroubleshooter_v3/OVERVIEW.md
+++ b/generated/google-apis-policytroubleshooter_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/iam/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-policytroubleshooter_v3/google-apis-policytroubleshooter_v3.gemspec
+++ b/generated/google-apis-policytroubleshooter_v3/google-apis-policytroubleshooter_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pollen_v1/OVERVIEW.md
+++ b/generated/google-apis-pollen_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/maps/documentation/pol
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pollen_v1/google-apis-pollen_v1.gemspec
+++ b/generated/google-apis-pollen_v1/google-apis-pollen_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-privateca_v1/OVERVIEW.md
+++ b/generated/google-apis-privateca_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-privateca_v1/google-apis-privateca_v1.gemspec
+++ b/generated/google-apis-privateca_v1/google-apis-privateca_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-privateca_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-privateca_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/) may provide guidance rega
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-privateca_v1beta1/google-apis-privateca_v1beta1.gemspec
+++ b/generated/google-apis-privateca_v1beta1/google-apis-privateca_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-prod_tt_sasportal_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-prod_tt_sasportal_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/spectrum-access-system
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-prod_tt_sasportal_v1alpha1/google-apis-prod_tt_sasportal_v1alpha1.gemspec
+++ b/generated/google-apis-prod_tt_sasportal_v1alpha1/google-apis-prod_tt_sasportal_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-publicca_v1/OVERVIEW.md
+++ b/generated/google-apis-publicca_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/public-certificate-authorit
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-publicca_v1/google-apis-publicca_v1.gemspec
+++ b/generated/google-apis-publicca_v1/google-apis-publicca_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-publicca_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-publicca_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/public-certificate-authorit
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-publicca_v1alpha1/google-apis-publicca_v1alpha1.gemspec
+++ b/generated/google-apis-publicca_v1alpha1/google-apis-publicca_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-publicca_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-publicca_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/public-certificate-authorit
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-publicca_v1beta1/google-apis-publicca_v1beta1.gemspec
+++ b/generated/google-apis-publicca_v1beta1/google-apis-publicca_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pubsub_v1/OVERVIEW.md
+++ b/generated/google-apis-pubsub_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/pubsub/docs) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pubsub_v1/google-apis-pubsub_v1.gemspec
+++ b/generated/google-apis-pubsub_v1/google-apis-pubsub_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pubsub_v1beta1a/OVERVIEW.md
+++ b/generated/google-apis-pubsub_v1beta1a/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/pubsub/docs) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pubsub_v1beta1a/google-apis-pubsub_v1beta1a.gemspec
+++ b/generated/google-apis-pubsub_v1beta1a/google-apis-pubsub_v1beta1a.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pubsub_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-pubsub_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/pubsub/docs) may provide gu
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pubsub_v1beta2/google-apis-pubsub_v1beta2.gemspec
+++ b/generated/google-apis-pubsub_v1beta2/google-apis-pubsub_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-pubsublite_v1/OVERVIEW.md
+++ b/generated/google-apis-pubsublite_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/pubsub/lite/docs) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-pubsublite_v1/google-apis-pubsublite_v1.gemspec
+++ b/generated/google-apis-pubsublite_v1/google-apis-pubsublite_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-rapidmigrationassessment_v1/OVERVIEW.md
+++ b/generated/google-apis-rapidmigrationassessment_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/migration-center) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-rapidmigrationassessment_v1/google-apis-rapidmigrationassessment_v1.gemspec
+++ b/generated/google-apis-rapidmigrationassessment_v1/google-apis-rapidmigrationassessment_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-readerrevenuesubscriptionlinking_v1/OVERVIEW.md
+++ b/generated/google-apis-readerrevenuesubscriptionlinking_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/news/subscribe/subscri
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-readerrevenuesubscriptionlinking_v1/google-apis-readerrevenuesubscriptionlinking_v1.gemspec
+++ b/generated/google-apis-readerrevenuesubscriptionlinking_v1/google-apis-readerrevenuesubscriptionlinking_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-realtimebidding_v1/OVERVIEW.md
+++ b/generated/google-apis-realtimebidding_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/authorized-buyers/apis
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-realtimebidding_v1/google-apis-realtimebidding_v1.gemspec
+++ b/generated/google-apis-realtimebidding_v1/google-apis-realtimebidding_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-recaptchaenterprise_v1/OVERVIEW.md
+++ b/generated/google-apis-recaptchaenterprise_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recaptcha-enterprise/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-recaptchaenterprise_v1/google-apis-recaptchaenterprise_v1.gemspec
+++ b/generated/google-apis-recaptchaenterprise_v1/google-apis-recaptchaenterprise_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-recommendationengine_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-recommendationengine_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommendations-ai/docs) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-recommendationengine_v1beta1/google-apis-recommendationengine_v1beta1.gemspec
+++ b/generated/google-apis-recommendationengine_v1beta1/google-apis-recommendationengine_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-recommender_v1/OVERVIEW.md
+++ b/generated/google-apis-recommender_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommender/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-recommender_v1/google-apis-recommender_v1.gemspec
+++ b/generated/google-apis-recommender_v1/google-apis-recommender_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-recommender_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-recommender_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommender/docs/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-recommender_v1beta1/google-apis-recommender_v1beta1.gemspec
+++ b/generated/google-apis-recommender_v1beta1/google-apis-recommender_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-redis_v1/OVERVIEW.md
+++ b/generated/google-apis-redis_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/memorystore/docs/redis/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-redis_v1/google-apis-redis_v1.gemspec
+++ b/generated/google-apis-redis_v1/google-apis-redis_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-redis_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-redis_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/memorystore/docs/redis/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-redis_v1beta1/google-apis-redis_v1beta1.gemspec
+++ b/generated/google-apis-redis_v1beta1/google-apis-redis_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-reseller_v1/OVERVIEW.md
+++ b/generated/google-apis-reseller_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/google-apps/reseller/)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-reseller_v1/google-apis-reseller_v1.gemspec
+++ b/generated/google-apis-reseller_v1/google-apis-reseller_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-retail_v2/OVERVIEW.md
+++ b/generated/google-apis-retail_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommendations) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-retail_v2/google-apis-retail_v2.gemspec
+++ b/generated/google-apis-retail_v2/google-apis-retail_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-retail_v2alpha/OVERVIEW.md
+++ b/generated/google-apis-retail_v2alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommendations) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-retail_v2alpha/google-apis-retail_v2alpha.gemspec
+++ b/generated/google-apis-retail_v2alpha/google-apis-retail_v2alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-retail_v2beta/OVERVIEW.md
+++ b/generated/google-apis-retail_v2beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/recommendations) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-retail_v2beta/google-apis-retail_v2beta.gemspec
+++ b/generated/google-apis-retail_v2beta/google-apis-retail_v2beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-run_v1/OVERVIEW.md
+++ b/generated/google-apis-run_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/run/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-run_v1/google-apis-run_v1.gemspec
+++ b/generated/google-apis-run_v1/google-apis-run_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-run_v2/OVERVIEW.md
+++ b/generated/google-apis-run_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/run/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-run_v2/google-apis-run_v2.gemspec
+++ b/generated/google-apis-run_v2/google-apis-run_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-runtimeconfig_v1/OVERVIEW.md
+++ b/generated/google-apis-runtimeconfig_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deployment-manager/runtime-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-runtimeconfig_v1/google-apis-runtimeconfig_v1.gemspec
+++ b/generated/google-apis-runtimeconfig_v1/google-apis-runtimeconfig_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-runtimeconfig_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-runtimeconfig_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/deployment-manager/runtime-
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-runtimeconfig_v1beta1/google-apis-runtimeconfig_v1beta1.gemspec
+++ b/generated/google-apis-runtimeconfig_v1beta1/google-apis-runtimeconfig_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-saasservicemgmt_v1/OVERVIEW.md
+++ b/generated/google-apis-saasservicemgmt_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/saas-runtime/docs) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-saasservicemgmt_v1/google-apis-saasservicemgmt_v1.gemspec
+++ b/generated/google-apis-saasservicemgmt_v1/google-apis-saasservicemgmt_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-saasservicemgmt_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-saasservicemgmt_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/saas-runtime/docs) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-saasservicemgmt_v1beta1/google-apis-saasservicemgmt_v1beta1.gemspec
+++ b/generated/google-apis-saasservicemgmt_v1beta1/google-apis-saasservicemgmt_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-safebrowsing_v4/OVERVIEW.md
+++ b/generated/google-apis-safebrowsing_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/safe-browsing/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-safebrowsing_v4/google-apis-safebrowsing_v4.gemspec
+++ b/generated/google-apis-safebrowsing_v4/google-apis-safebrowsing_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-safebrowsing_v5/OVERVIEW.md
+++ b/generated/google-apis-safebrowsing_v5/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/safe-browsing/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-safebrowsing_v5/google-apis-safebrowsing_v5.gemspec
+++ b/generated/google-apis-safebrowsing_v5/google-apis-safebrowsing_v5.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sasportal_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-sasportal_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/spectrum-access-system
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sasportal_v1alpha1/google-apis-sasportal_v1alpha1.gemspec
+++ b/generated/google-apis-sasportal_v1alpha1/google-apis-sasportal_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-script_v1/OVERVIEW.md
+++ b/generated/google-apis-script_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/apps-script/api/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-script_v1/google-apis-script_v1.gemspec
+++ b/generated/google-apis-script_v1/google-apis-script_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-searchads360_v0/OVERVIEW.md
+++ b/generated/google-apis-searchads360_v0/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/search-ads/reporting) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-searchads360_v0/google-apis-searchads360_v0.gemspec
+++ b/generated/google-apis-searchads360_v0/google-apis-searchads360_v0.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-searchads360_v23/OVERVIEW.md
+++ b/generated/google-apis-searchads360_v23/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/search-ads/reporting) 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-searchads360_v23/google-apis-searchads360_v23.gemspec
+++ b/generated/google-apis-searchads360_v23/google-apis-searchads360_v23.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-searchconsole_v1/OVERVIEW.md
+++ b/generated/google-apis-searchconsole_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/webmaster-tools/about)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-searchconsole_v1/google-apis-searchconsole_v1.gemspec
+++ b/generated/google-apis-searchconsole_v1/google-apis-searchconsole_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-secretmanager_v1/OVERVIEW.md
+++ b/generated/google-apis-secretmanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/secret-manager/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-secretmanager_v1/google-apis-secretmanager_v1.gemspec
+++ b/generated/google-apis-secretmanager_v1/google-apis-secretmanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-secretmanager_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-secretmanager_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/secret-manager/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-secretmanager_v1beta1/google-apis-secretmanager_v1beta1.gemspec
+++ b/generated/google-apis-secretmanager_v1beta1/google-apis-secretmanager_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-secretmanager_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-secretmanager_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/secret-manager/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-secretmanager_v1beta2/google-apis-secretmanager_v1beta2.gemspec
+++ b/generated/google-apis-secretmanager_v1beta2/google-apis-secretmanager_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-securesourcemanager_v1/OVERVIEW.md
+++ b/generated/google-apis-securesourcemanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/secure-source-manager) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-securesourcemanager_v1/google-apis-securesourcemanager_v1.gemspec
+++ b/generated/google-apis-securesourcemanager_v1/google-apis-securesourcemanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-securitycenter_v1/OVERVIEW.md
+++ b/generated/google-apis-securitycenter_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-securitycenter_v1/google-apis-securitycenter_v1.gemspec
+++ b/generated/google-apis-securitycenter_v1/google-apis-securitycenter_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-securitycenter_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-securitycenter_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-securitycenter_v1beta1/google-apis-securitycenter_v1beta1.gemspec
+++ b/generated/google-apis-securitycenter_v1beta1/google-apis-securitycenter_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-securitycenter_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-securitycenter_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-securitycenter_v1beta2/google-apis-securitycenter_v1beta2.gemspec
+++ b/generated/google-apis-securitycenter_v1beta2/google-apis-securitycenter_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-securityposture_v1/OVERVIEW.md
+++ b/generated/google-apis-securityposture_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-securityposture_v1/google-apis-securityposture_v1.gemspec
+++ b/generated/google-apis-securityposture_v1/google-apis-securityposture_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-serviceconsumermanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-serviceconsumermanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-consumer-management
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-serviceconsumermanagement_v1/google-apis-serviceconsumermanagement_v1.gemspec
+++ b/generated/google-apis-serviceconsumermanagement_v1/google-apis-serviceconsumermanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-serviceconsumermanagement_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-serviceconsumermanagement_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-consumer-management
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-serviceconsumermanagement_v1beta1/google-apis-serviceconsumermanagement_v1beta1.gemspec
+++ b/generated/google-apis-serviceconsumermanagement_v1beta1/google-apis-serviceconsumermanagement_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicecontrol_v1/OVERVIEW.md
+++ b/generated/google-apis-servicecontrol_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-control/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicecontrol_v1/google-apis-servicecontrol_v1.gemspec
+++ b/generated/google-apis-servicecontrol_v1/google-apis-servicecontrol_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicecontrol_v2/OVERVIEW.md
+++ b/generated/google-apis-servicecontrol_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-control/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicecontrol_v2/google-apis-servicecontrol_v2.gemspec
+++ b/generated/google-apis-servicecontrol_v2/google-apis-servicecontrol_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicedirectory_v1/OVERVIEW.md
+++ b/generated/google-apis-servicedirectory_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-directory) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicedirectory_v1/google-apis-servicedirectory_v1.gemspec
+++ b/generated/google-apis-servicedirectory_v1/google-apis-servicedirectory_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicedirectory_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-servicedirectory_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-directory) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicedirectory_v1beta1/google-apis-servicedirectory_v1beta1.gemspec
+++ b/generated/google-apis-servicedirectory_v1beta1/google-apis-servicedirectory_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicemanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-servicemanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-management/) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicemanagement_v1/google-apis-servicemanagement_v1.gemspec
+++ b/generated/google-apis-servicemanagement_v1/google-apis-servicemanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicenetworking_v1/OVERVIEW.md
+++ b/generated/google-apis-servicenetworking_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-infrastructure/docs
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicenetworking_v1/google-apis-servicenetworking_v1.gemspec
+++ b/generated/google-apis-servicenetworking_v1/google-apis-servicenetworking_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-servicenetworking_v1beta/OVERVIEW.md
+++ b/generated/google-apis-servicenetworking_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-infrastructure/docs
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-servicenetworking_v1beta/google-apis-servicenetworking_v1beta.gemspec
+++ b/generated/google-apis-servicenetworking_v1beta/google-apis-servicenetworking_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-serviceusage_v1/OVERVIEW.md
+++ b/generated/google-apis-serviceusage_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-usage/) may provide
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-serviceusage_v1/google-apis-serviceusage_v1.gemspec
+++ b/generated/google-apis-serviceusage_v1/google-apis-serviceusage_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-serviceusage_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-serviceusage_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/service-usage/) may provide
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-serviceusage_v1beta1/google-apis-serviceusage_v1beta1.gemspec
+++ b/generated/google-apis-serviceusage_v1beta1/google-apis-serviceusage_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sheets_v4/OVERVIEW.md
+++ b/generated/google-apis-sheets_v4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/sheets/) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sheets_v4/google-apis-sheets_v4.gemspec
+++ b/generated/google-apis-sheets_v4/google-apis-sheets_v4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-site_verification_v1/OVERVIEW.md
+++ b/generated/google-apis-site_verification_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/site-verification/) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-site_verification_v1/google-apis-site_verification_v1.gemspec
+++ b/generated/google-apis-site_verification_v1/google-apis-site_verification_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-slides_v1/OVERVIEW.md
+++ b/generated/google-apis-slides_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/slides/) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-slides_v1/google-apis-slides_v1.gemspec
+++ b/generated/google-apis-slides_v1/google-apis-slides_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-smartdevicemanagement_v1/OVERVIEW.md
+++ b/generated/google-apis-smartdevicemanagement_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/nest/device-access) ma
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-smartdevicemanagement_v1/google-apis-smartdevicemanagement_v1.gemspec
+++ b/generated/google-apis-smartdevicemanagement_v1/google-apis-smartdevicemanagement_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-solar_v1/OVERVIEW.md
+++ b/generated/google-apis-solar_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/maps/documentation/sol
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-solar_v1/google-apis-solar_v1.gemspec
+++ b/generated/google-apis-solar_v1/google-apis-solar_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-spanner_v1/OVERVIEW.md
+++ b/generated/google-apis-spanner_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/spanner/) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-spanner_v1/google-apis-spanner_v1.gemspec
+++ b/generated/google-apis-spanner_v1/google-apis-spanner_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-speech_v1/OVERVIEW.md
+++ b/generated/google-apis-speech_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/speech-to-text/docs/quickst
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-speech_v1/google-apis-speech_v1.gemspec
+++ b/generated/google-apis-speech_v1/google-apis-speech_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-speech_v1p1beta1/OVERVIEW.md
+++ b/generated/google-apis-speech_v1p1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/speech-to-text/docs/quickst
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-speech_v1p1beta1/google-apis-speech_v1p1beta1.gemspec
+++ b/generated/google-apis-speech_v1p1beta1/google-apis-speech_v1p1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sqladmin_v1/OVERVIEW.md
+++ b/generated/google-apis-sqladmin_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/sql/docs) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sqladmin_v1/google-apis-sqladmin_v1.gemspec
+++ b/generated/google-apis-sqladmin_v1/google-apis-sqladmin_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sqladmin_v1beta4/OVERVIEW.md
+++ b/generated/google-apis-sqladmin_v1beta4/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/sql/docs) may provide guida
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sqladmin_v1beta4/google-apis-sqladmin_v1beta4.gemspec
+++ b/generated/google-apis-sqladmin_v1beta4/google-apis-sqladmin_v1beta4.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-storage_v1/OVERVIEW.md
+++ b/generated/google-apis-storage_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/storage/docs/json_api/
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-storage_v1/google-apis-storage_v1.gemspec
+++ b/generated/google-apis-storage_v1/google-apis-storage_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-storagebatchoperations_v1/OVERVIEW.md
+++ b/generated/google-apis-storagebatchoperations_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/storage/docs/batch-operatio
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-storagebatchoperations_v1/google-apis-storagebatchoperations_v1.gemspec
+++ b/generated/google-apis-storagebatchoperations_v1/google-apis-storagebatchoperations_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-storagetransfer_v1/OVERVIEW.md
+++ b/generated/google-apis-storagetransfer_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/storage-transfer/docs) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-storagetransfer_v1/google-apis-storagetransfer_v1.gemspec
+++ b/generated/google-apis-storagetransfer_v1/google-apis-storagetransfer_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-streetviewpublish_v1/OVERVIEW.md
+++ b/generated/google-apis-streetviewpublish_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/streetview/publish/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-streetviewpublish_v1/google-apis-streetviewpublish_v1.gemspec
+++ b/generated/google-apis-streetviewpublish_v1/google-apis-streetviewpublish_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sts_v1/OVERVIEW.md
+++ b/generated/google-apis-sts_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://cloud.google.com/iam/docs/workload-identity-f
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sts_v1/google-apis-sts_v1.gemspec
+++ b/generated/google-apis-sts_v1/google-apis-sts_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-sts_v1beta/OVERVIEW.md
+++ b/generated/google-apis-sts_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](http://cloud.google.com/iam/docs/workload-identity-f
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-sts_v1beta/google-apis-sts_v1beta.gemspec
+++ b/generated/google-apis-sts_v1beta/google-apis-sts_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tagmanager_v1/OVERVIEW.md
+++ b/generated/google-apis-tagmanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/tag-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tagmanager_v1/google-apis-tagmanager_v1.gemspec
+++ b/generated/google-apis-tagmanager_v1/google-apis-tagmanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tagmanager_v2/OVERVIEW.md
+++ b/generated/google-apis-tagmanager_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/tag-manager) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tagmanager_v2/google-apis-tagmanager_v2.gemspec
+++ b/generated/google-apis-tagmanager_v2/google-apis-tagmanager_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tasks_v1/OVERVIEW.md
+++ b/generated/google-apis-tasks_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/tasks/) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tasks_v1/google-apis-tasks_v1.gemspec
+++ b/generated/google-apis-tasks_v1/google-apis-tasks_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-testing_v1/OVERVIEW.md
+++ b/generated/google-apis-testing_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/test-lab/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-testing_v1/google-apis-testing_v1.gemspec
+++ b/generated/google-apis-testing_v1/google-apis-testing_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-texttospeech_v1/OVERVIEW.md
+++ b/generated/google-apis-texttospeech_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/text-to-speech/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-texttospeech_v1/google-apis-texttospeech_v1.gemspec
+++ b/generated/google-apis-texttospeech_v1/google-apis-texttospeech_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-texttospeech_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-texttospeech_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/text-to-speech/) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-texttospeech_v1beta1/google-apis-texttospeech_v1beta1.gemspec
+++ b/generated/google-apis-texttospeech_v1beta1/google-apis-texttospeech_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-threatintelligence_v1beta/OVERVIEW.md
+++ b/generated/google-apis-threatintelligence_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://docs.cloud.google.com/threatintelligence/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-threatintelligence_v1beta/google-apis-threatintelligence_v1beta.gemspec
+++ b/generated/google-apis-threatintelligence_v1beta/google-apis-threatintelligence_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-toolresults_v1beta3/OVERVIEW.md
+++ b/generated/google-apis-toolresults_v1beta3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://firebase.google.com/docs/test-lab/) may prov
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-toolresults_v1beta3/google-apis-toolresults_v1beta3.gemspec
+++ b/generated/google-apis-toolresults_v1beta3/google-apis-toolresults_v1beta3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tpu_v1/OVERVIEW.md
+++ b/generated/google-apis-tpu_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tpu/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tpu_v1/google-apis-tpu_v1.gemspec
+++ b/generated/google-apis-tpu_v1/google-apis-tpu_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tpu_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-tpu_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tpu/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tpu_v1alpha1/google-apis-tpu_v1alpha1.gemspec
+++ b/generated/google-apis-tpu_v1alpha1/google-apis-tpu_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tpu_v2/OVERVIEW.md
+++ b/generated/google-apis-tpu_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tpu/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tpu_v2/google-apis-tpu_v2.gemspec
+++ b/generated/google-apis-tpu_v2/google-apis-tpu_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-tpu_v2alpha1/OVERVIEW.md
+++ b/generated/google-apis-tpu_v2alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/tpu/) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-tpu_v2alpha1/google-apis-tpu_v2alpha1.gemspec
+++ b/generated/google-apis-tpu_v2alpha1/google-apis-tpu_v2alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-trafficdirector_v2/OVERVIEW.md
+++ b/generated/google-apis-trafficdirector_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/traffic-director) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-trafficdirector_v2/google-apis-trafficdirector_v2.gemspec
+++ b/generated/google-apis-trafficdirector_v2/google-apis-trafficdirector_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-trafficdirector_v3/OVERVIEW.md
+++ b/generated/google-apis-trafficdirector_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/traffic-director) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-trafficdirector_v3/google-apis-trafficdirector_v3.gemspec
+++ b/generated/google-apis-trafficdirector_v3/google-apis-trafficdirector_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-transcoder_v1/OVERVIEW.md
+++ b/generated/google-apis-transcoder_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/transcoder/docs/) may provi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-transcoder_v1/google-apis-transcoder_v1.gemspec
+++ b/generated/google-apis-transcoder_v1/google-apis-transcoder_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-translate_v2/OVERVIEW.md
+++ b/generated/google-apis-translate_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://code.google.com/apis/language/translate/v2/g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-translate_v2/google-apis-translate_v2.gemspec
+++ b/generated/google-apis-translate_v2/google-apis-translate_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-translate_v3/OVERVIEW.md
+++ b/generated/google-apis-translate_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/translate/docs/quickstarts)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-translate_v3/google-apis-translate_v3.gemspec
+++ b/generated/google-apis-translate_v3/google-apis-translate_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-translate_v3beta1/OVERVIEW.md
+++ b/generated/google-apis-translate_v3beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/translate/docs/quickstarts)
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-translate_v3beta1/google-apis-translate_v3beta1.gemspec
+++ b/generated/google-apis-translate_v3beta1/google-apis-translate_v3beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-travelimpactmodel_v1/OVERVIEW.md
+++ b/generated/google-apis-travelimpactmodel_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/travel/impact-model) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-travelimpactmodel_v1/google-apis-travelimpactmodel_v1.gemspec
+++ b/generated/google-apis-travelimpactmodel_v1/google-apis-travelimpactmodel_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vault_v1/OVERVIEW.md
+++ b/generated/google-apis-vault_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/vault) may p
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vault_v1/google-apis-vault_v1.gemspec
+++ b/generated/google-apis-vault_v1/google-apis-vault_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-verifiedaccess_v1/OVERVIEW.md
+++ b/generated/google-apis-verifiedaccess_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/chrome/verified-access
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-verifiedaccess_v1/google-apis-verifiedaccess_v1.gemspec
+++ b/generated/google-apis-verifiedaccess_v1/google-apis-verifiedaccess_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-verifiedaccess_v2/OVERVIEW.md
+++ b/generated/google-apis-verifiedaccess_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/chrome/verified-access
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-verifiedaccess_v2/google-apis-verifiedaccess_v2.gemspec
+++ b/generated/google-apis-verifiedaccess_v2/google-apis-verifiedaccess_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-versionhistory_v1/OVERVIEW.md
+++ b/generated/google-apis-versionhistory_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developer.chrome.com/docs/web-platform/versi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-versionhistory_v1/google-apis-versionhistory_v1.gemspec
+++ b/generated/google-apis-versionhistory_v1/google-apis-versionhistory_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-videointelligence_v1/OVERVIEW.md
+++ b/generated/google-apis-videointelligence_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/video-intelligence/docs/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-videointelligence_v1/google-apis-videointelligence_v1.gemspec
+++ b/generated/google-apis-videointelligence_v1/google-apis-videointelligence_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-videointelligence_v1beta2/OVERVIEW.md
+++ b/generated/google-apis-videointelligence_v1beta2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/video-intelligence/docs/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-videointelligence_v1beta2/google-apis-videointelligence_v1beta2.gemspec
+++ b/generated/google-apis-videointelligence_v1beta2/google-apis-videointelligence_v1beta2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-videointelligence_v1p1beta1/OVERVIEW.md
+++ b/generated/google-apis-videointelligence_v1p1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/video-intelligence/docs/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-videointelligence_v1p1beta1/google-apis-videointelligence_v1p1beta1.gemspec
+++ b/generated/google-apis-videointelligence_v1p1beta1/google-apis-videointelligence_v1p1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-videointelligence_v1p2beta1/OVERVIEW.md
+++ b/generated/google-apis-videointelligence_v1p2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/video-intelligence/docs/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-videointelligence_v1p2beta1/google-apis-videointelligence_v1p2beta1.gemspec
+++ b/generated/google-apis-videointelligence_v1p2beta1/google-apis-videointelligence_v1p2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-videointelligence_v1p3beta1/OVERVIEW.md
+++ b/generated/google-apis-videointelligence_v1p3beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/video-intelligence/docs/) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-videointelligence_v1p3beta1/google-apis-videointelligence_v1p3beta1.gemspec
+++ b/generated/google-apis-videointelligence_v1p3beta1/google-apis-videointelligence_v1p3beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vision_v1/OVERVIEW.md
+++ b/generated/google-apis-vision_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vision/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vision_v1/google-apis-vision_v1.gemspec
+++ b/generated/google-apis-vision_v1/google-apis-vision_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vision_v1p1beta1/OVERVIEW.md
+++ b/generated/google-apis-vision_v1p1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vision/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vision_v1p1beta1/google-apis-vision_v1p1beta1.gemspec
+++ b/generated/google-apis-vision_v1p1beta1/google-apis-vision_v1p1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vision_v1p2beta1/OVERVIEW.md
+++ b/generated/google-apis-vision_v1p2beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vision/) may provide guidan
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vision_v1p2beta1/google-apis-vision_v1p2beta1.gemspec
+++ b/generated/google-apis-vision_v1p2beta1/google-apis-vision_v1p2beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vmmigration_v1/OVERVIEW.md
+++ b/generated/google-apis-vmmigration_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/migrate/virtual-machines) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vmmigration_v1/google-apis-vmmigration_v1.gemspec
+++ b/generated/google-apis-vmmigration_v1/google-apis-vmmigration_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vmmigration_v1alpha1/OVERVIEW.md
+++ b/generated/google-apis-vmmigration_v1alpha1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/migrate/virtual-machines) m
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vmmigration_v1alpha1/google-apis-vmmigration_v1alpha1.gemspec
+++ b/generated/google-apis-vmmigration_v1alpha1/google-apis-vmmigration_v1alpha1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vmwareengine_v1/OVERVIEW.md
+++ b/generated/google-apis-vmwareengine_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/solutions/vmware-as-a-servi
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vmwareengine_v1/google-apis-vmwareengine_v1.gemspec
+++ b/generated/google-apis-vmwareengine_v1/google-apis-vmwareengine_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vpcaccess_v1/OVERVIEW.md
+++ b/generated/google-apis-vpcaccess_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vpc/docs/configure-serverle
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vpcaccess_v1/google-apis-vpcaccess_v1.gemspec
+++ b/generated/google-apis-vpcaccess_v1/google-apis-vpcaccess_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-vpcaccess_v1beta1/OVERVIEW.md
+++ b/generated/google-apis-vpcaccess_v1beta1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/vpc/docs/configure-serverle
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-vpcaccess_v1beta1/google-apis-vpcaccess_v1beta1.gemspec
+++ b/generated/google-apis-vpcaccess_v1beta1/google-apis-vpcaccess_v1beta1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-walletobjects_v1/OVERVIEW.md
+++ b/generated/google-apis-walletobjects_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/pay/passes) may provid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-walletobjects_v1/google-apis-walletobjects_v1.gemspec
+++ b/generated/google-apis-walletobjects_v1/google-apis-walletobjects_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-webcontentpublisher_v1/OVERVIEW.md
+++ b/generated/google-apis-webcontentpublisher_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/news/subscribe) may pr
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-webcontentpublisher_v1/google-apis-webcontentpublisher_v1.gemspec
+++ b/generated/google-apis-webcontentpublisher_v1/google-apis-webcontentpublisher_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-webfonts_v1/OVERVIEW.md
+++ b/generated/google-apis-webfonts_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/fonts/docs/developer_a
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-webfonts_v1/google-apis-webfonts_v1.gemspec
+++ b/generated/google-apis-webfonts_v1/google-apis-webfonts_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-webrisk_v1/OVERVIEW.md
+++ b/generated/google-apis-webrisk_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/web-risk/) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-webrisk_v1/google-apis-webrisk_v1.gemspec
+++ b/generated/google-apis-webrisk_v1/google-apis-webrisk_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-websecurityscanner_v1/OVERVIEW.md
+++ b/generated/google-apis-websecurityscanner_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center/doc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-websecurityscanner_v1/google-apis-websecurityscanner_v1.gemspec
+++ b/generated/google-apis-websecurityscanner_v1/google-apis-websecurityscanner_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-websecurityscanner_v1alpha/OVERVIEW.md
+++ b/generated/google-apis-websecurityscanner_v1alpha/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center/doc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-websecurityscanner_v1alpha/google-apis-websecurityscanner_v1alpha.gemspec
+++ b/generated/google-apis-websecurityscanner_v1alpha/google-apis-websecurityscanner_v1alpha.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-websecurityscanner_v1beta/OVERVIEW.md
+++ b/generated/google-apis-websecurityscanner_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/security-command-center/doc
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-websecurityscanner_v1beta/google-apis-websecurityscanner_v1beta.gemspec
+++ b/generated/google-apis-websecurityscanner_v1beta/google-apis-websecurityscanner_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workflowexecutions_v1/OVERVIEW.md
+++ b/generated/google-apis-workflowexecutions_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workflows) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workflowexecutions_v1/google-apis-workflowexecutions_v1.gemspec
+++ b/generated/google-apis-workflowexecutions_v1/google-apis-workflowexecutions_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workflowexecutions_v1beta/OVERVIEW.md
+++ b/generated/google-apis-workflowexecutions_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workflows) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workflowexecutions_v1beta/google-apis-workflowexecutions_v1beta.gemspec
+++ b/generated/google-apis-workflowexecutions_v1beta/google-apis-workflowexecutions_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workflows_v1/OVERVIEW.md
+++ b/generated/google-apis-workflows_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workflows) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workflows_v1/google-apis-workflows_v1.gemspec
+++ b/generated/google-apis-workflows_v1/google-apis-workflows_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workflows_v1beta/OVERVIEW.md
+++ b/generated/google-apis-workflows_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workflows) may provide guid
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workflows_v1beta/google-apis-workflows_v1beta.gemspec
+++ b/generated/google-apis-workflows_v1beta/google-apis-workflows_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workloadmanager_v1/OVERVIEW.md
+++ b/generated/google-apis-workloadmanager_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workload-manager/docs) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workloadmanager_v1/google-apis-workloadmanager_v1.gemspec
+++ b/generated/google-apis-workloadmanager_v1/google-apis-workloadmanager_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workspaceevents_v1/OVERVIEW.md
+++ b/generated/google-apis-workspaceevents_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/workspace/events) may 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workspaceevents_v1/google-apis-workspaceevents_v1.gemspec
+++ b/generated/google-apis-workspaceevents_v1/google-apis-workspaceevents_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workstations_v1/OVERVIEW.md
+++ b/generated/google-apis-workstations_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workstations) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workstations_v1/google-apis-workstations_v1.gemspec
+++ b/generated/google-apis-workstations_v1/google-apis-workstations_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-workstations_v1beta/OVERVIEW.md
+++ b/generated/google-apis-workstations_v1beta/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://cloud.google.com/workstations) may provide g
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-workstations_v1beta/google-apis-workstations_v1beta.gemspec
+++ b/generated/google-apis-workstations_v1beta/google-apis-workstations_v1beta.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-youtube_analytics_v2/OVERVIEW.md
+++ b/generated/google-apis-youtube_analytics_v2/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/youtube/analytics) may
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-youtube_analytics_v2/google-apis-youtube_analytics_v2.gemspec
+++ b/generated/google-apis-youtube_analytics_v2/google-apis-youtube_analytics_v2.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-youtube_v3/OVERVIEW.md
+++ b/generated/google-apis-youtube_v3/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/youtube/) may provide 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-youtube_v3/google-apis-youtube_v3.gemspec
+++ b/generated/google-apis-youtube_v3/google-apis-youtube_v3.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/generated/google-apis-youtubereporting_v1/OVERVIEW.md
+++ b/generated/google-apis-youtubereporting_v1/OVERVIEW.md
@@ -83,7 +83,7 @@ The [product documentation](https://developers.google.com/youtube/reporting/v1/r
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 

--- a/generated/google-apis-youtubereporting_v1/google-apis-youtubereporting_v1.gemspec
+++ b/generated/google-apis-youtubereporting_v1/google-apis-youtubereporting_v1.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "representable", "~> 3.0"
   gem.add_runtime_dependency "retriable", "~> 3.1"
   gem.add_runtime_dependency "addressable", "~> 2.8", ">= 2.8.7"

--- a/google-apis-generator/google-apis-generator.gemspec
+++ b/google-apis-generator/google-apis-generator.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.executables = ["generate-api"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
   gem.add_runtime_dependency "activesupport", ">= 5.0"
   gem.add_runtime_dependency "gems", "~> 1.2"
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"

--- a/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
@@ -83,7 +83,7 @@ The [product documentation](<%= api.documentation_link %>) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 


### PR DESCRIPTION
Drop support for Ruby 3.1.
Update gemspecs, templates, and CI configuration.

TAG=agy
CONV=841e5655-150e-4109-9373-284484c1ac9e
