### PR TITLE
feat: ruby 3.2 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            task: "--include-spec"
-          - os: ubuntu-latest
             ruby: "3.2"
             task: "--include-spec"
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ services.
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
-Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Currently, this means Ruby 2.7 and later. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
+Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Currently, this means Ruby 3.2 and later. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 
 ## License
 

--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "representable", "~> 3.0"
   gem.add_runtime_dependency "retriable", "~> 3.1"
   gem.add_runtime_dependency "addressable", "~> 2.8", ">= 2.8.7"

--- a/google-apis-generator/google-apis-generator.gemspec
+++ b/google-apis-generator/google-apis-generator.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.executables = ["generate-api"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
   gem.add_runtime_dependency "activesupport", ">= 5.0"
   gem.add_runtime_dependency "gems", "~> 1.2"
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"

--- a/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/gemspec.tmpl
@@ -28,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
   gem.add_runtime_dependency "google-apis-core", ">= 0.15.0", "< 2.a"
 end

--- a/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
+++ b/google-apis-generator/lib/google/apis/generator/templates/overview.md.tmpl
@@ -83,7 +83,7 @@ The [product documentation](<%= api.documentation_link %>) may provide guidance 
 
 ## Supported Ruby versions
 
-This library is supported on Ruby 3.1+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported by Ruby Core -- that is, Ruby versions that are either in normal maintenance or in security maintenance, and not end of life. Older versions of Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby support schedule.
 


### PR DESCRIPTION
Updates the minimum supported Ruby version to 3.2, dropping support for Ruby 3.1 (which reached EOL in March 2025).

This is part of the routine yearly maintenance around Ruby EOL dates.

Note: Changes to the auto-generated clients under `generated/` have been excluded from this PR and will be handled by the CI generator in a subsequent step.