### PR TITLE
fix(google-apis-core): Add missing multi_json runtime dependency for representable

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -56,6 +56,13 @@ def run
     dirs.each { |dir| puts "  #{dir}" }
   end
 
+  if dirs.include? 'google-apis-core'
+    puts 'Installing local google-apis-core changes...'
+    Dir.chdir 'google-apis-core' do
+      exec ['toys', 'install', '--yes']
+    end
+  end
+
   dirs.each { |dir| run_in_dir dir }
 end
 

--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -1,30 +1,31 @@
-require File.expand_path("lib/google/apis/core/version", __dir__)
+require File.expand_path('lib/google/apis/core/version', __dir__)
 gem_version = Google::Apis::Core::VERSION
 
 Gem::Specification.new do |gem|
-  gem.name = "google-apis-core"
+  gem.name = 'google-apis-core'
   gem.version = gem_version
-  gem.authors = ["Google LLC"]
-  gem.email = "googleapis-packages@google.com"
-  gem.summary = "Common utility and base classes for legacy Google REST clients"
-  gem.homepage = "https://github.com/google/google-api-ruby-client"
-  gem.license = "Apache-2.0"
+  gem.authors = ['Google LLC']
+  gem.email = 'googleapis-packages@google.com'
+  gem.summary = 'Common utility and base classes for legacy Google REST clients'
+  gem.homepage = 'https://github.com/google/google-api-ruby-client'
+  gem.license = 'Apache-2.0'
   gem.metadata = {
-    "bug_tracker_uri" => "https://github.com/googleapis/google-api-ruby-client/issues",
-    "changelog_uri" => "https://github.com/googleapis/google-api-ruby-client/tree/main/google-apis-core/CHANGELOG.md",
-    "documentation_uri" => "https://googleapis.dev/ruby/google-apis-core/v#{gem_version}",
-    "source_code_uri" => "https://github.com/googleapis/google-api-ruby-client/tree/main/google-apis-core"
+    'bug_tracker_uri' => 'https://github.com/googleapis/google-api-ruby-client/issues',
+    'changelog_uri' => 'https://github.com/googleapis/google-api-ruby-client/tree/main/google-apis-core/CHANGELOG.md',
+    'documentation_uri' => "https://googleapis.dev/ruby/google-apis-core/v#{gem_version}",
+    'source_code_uri' => 'https://github.com/googleapis/google-api-ruby-client/tree/main/google-apis-core'
   }
 
-  gem.files = Dir.glob("lib/**/*.rb") + Dir.glob("*.md") + [".yardopts"]
-  gem.require_paths = ["lib"]
+  gem.files = Dir.glob('lib/**/*.rb') + Dir.glob('*.md') + ['.yardopts']
+  gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 3.2'
-  gem.add_runtime_dependency "representable", "~> 3.0"
-  gem.add_runtime_dependency "retriable", "~> 3.1"
-  gem.add_runtime_dependency "addressable", "~> 2.8", ">= 2.8.7"
-  gem.add_runtime_dependency "mini_mime", "~> 1.1"
-  gem.add_runtime_dependency "googleauth", "~> 1.14"
-  gem.add_runtime_dependency "faraday", "~> 2.13"
-  gem.add_runtime_dependency "faraday-follow_redirects", "~> 0.3"
+  gem.add_runtime_dependency 'addressable', '~> 2.8', '>= 2.8.7'
+  gem.add_runtime_dependency 'faraday', '~> 2.13'
+  gem.add_runtime_dependency 'faraday-follow_redirects', '~> 0.3'
+  gem.add_runtime_dependency 'googleauth', '~> 1.14'
+  gem.add_runtime_dependency 'mini_mime', '~> 1.1'
+  gem.add_runtime_dependency 'multi_json', '~> 1.11'
+  gem.add_runtime_dependency 'representable', '~> 3.0'
+  gem.add_runtime_dependency 'retriable', '~> 3.1'
 end


### PR DESCRIPTION
* multi_json was removed from upstream dependencies googleauth (googleapis/google-auth-library-ruby#575) and signet (googleapis/signet#273).
* representable documents that if you use representable/json, you must include multi_json in your own dependencies.
* Fix CI loading of local changes to google-apis-core.
* Run rubocop -a to reformat and sort google-apis-core.gemspec.

fixes: #26611
fixes: #26613