### PR TITLE
chore: Add Ruby 4.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,16 @@ jobs:
             task: "--include-spec"
           - os: ubuntu-latest
             ruby: "3.4"
+            task: "--include-spec"
+          - os: ubuntu-latest
+            ruby: "4.0"
             task: "--include-spec --include-yardoc --include-build"
             rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
           - os: macos-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: "--include-spec"
           - os: windows-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: "--include-spec"
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.4
+      - name: Install Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.4
+      - name: Install Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/release-unfreeze.yml
+++ b/.github/workflows/release-unfreeze.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.4
+      - name: Install Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/weekly-generate-updates.yml
+++ b/.github/workflows/weekly-generate-updates.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.4
+      - name: Install Ruby 4.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/google-apis-core/Gemfile
+++ b/google-apis-core/Gemfile
@@ -12,8 +12,10 @@ group :development do
   gem 'launchy', '~> 2.4'
   gem 'dotenv', '~> 2.0'
   gem 'fakefs', '>= 1.0', '< 4', require: "fakefs/safe"
+  gem "fiddle", "~> 1.1"
   gem 'google-id-token', '~> 1.3'
   gem 'os', '~> 0.9'
+  gem 'ostruct', '~> 0.5.5'
   gem 'rmail', '~> 1.1'
   gem 'redis', '>= 3.2', '< 5.0.8'
   gem 'logging', '~> 2.2'

--- a/google-apis-generator/Gemfile
+++ b/google-apis-generator/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 group :development do
   gem 'bundler', '>= 1.7'
+  gem 'irb', '~> 1.18'
+  gem 'ostruct', '~> 0.5.5'
+  gem "fiddle", "~> 1.1"
   gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.1'
   gem 'json_spec', '~> 1.1'


### PR DESCRIPTION
Adding specific gems as they were unbundled from Ruby 4.0:

`.../windows.rb:1: warning: fiddle/import is found in fiddle, which is not part of the default gems since Ruby 4.0.`

Pinning to these specific versions due to CI constraints.

`ostruct` `0.5.5` is required due to:
```
The source contains the following gems matching 'ostruct':

  * ostruct-0.5.5

	from /opt/hostedtoolcache/Ruby/3.2.11/x64/lib/ruby/3.2.0/bundler/resolver.rb:357:in `block in prepare_dependencies'

	from /opt/hostedtoolcache/Ruby/3.2.11/x64/lib/ruby/3.2.0/bundler/resolver.rb:342:in `each'
       ...
 ```
 
 Similarly for `fiddle`.

Fixes #26615 