### PR TITLE
chore: preload digest/sha2 to avoid Digest::Base inheritance error

### DIFF
--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Avoid thread-safety issues with autoloading digest/sha2 in Bundler 4
+require "digest/sha2"
 
 expand :clean, paths: :gitignore
 


### PR DESCRIPTION
On Windows, parallel threads trigger the autoload of `digest/sha2` simultaneously. As autoloading C-extensions in parallel is not thread-safe, this causes a class allocation failure:
`RuntimeError: Digest::Base cannot be directly inherited in Ruby`

Preloading `digest/sha2` in the main thread of `toys` ensures it is fully loaded before any background threads are spawned.