### PR TITLE
fix(google-apis-core): Relax retriable dependency constraint

### DIFF
--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'mini_mime', '~> 1.1'
   gem.add_runtime_dependency 'multi_json', '~> 1.11'
   gem.add_runtime_dependency 'representable', '~> 3.0'
-  gem.add_runtime_dependency 'retriable', '~> 3.1'
+  gem.add_runtime_dependency 'retriable', '>= 3.1'
 end

--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'mini_mime', '~> 1.1'
   gem.add_runtime_dependency 'multi_json', '~> 1.11'
   gem.add_runtime_dependency 'representable', '~> 3.0'
-  gem.add_runtime_dependency 'retriable', '>= 3.1'
+  gem.add_runtime_dependency 'retriable', '>= 3.1', '< 5.0'
 end


### PR DESCRIPTION
Change retriable dependency constraint to '>= 3.1' to support 4.x major versions.

Manually verified the test suite runs successfully against retriable 4.1.1.

fixes: #26620