### PR TITLE
fix: upgrade addressable dependency to ~> 2.9

### DIFF
--- a/google-apis-core/google-apis-core.gemspec
+++ b/google-apis-core/google-apis-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 3.2'
-  gem.add_runtime_dependency 'addressable', '~> 2.8', '>= 2.8.7'
+  gem.add_runtime_dependency 'addressable', '~> 2.9'
   gem.add_runtime_dependency 'faraday', '~> 2.13'
   gem.add_runtime_dependency 'faraday-follow_redirects', '~> 0.3'
   gem.add_runtime_dependency 'googleauth', '~> 1.14'


### PR DESCRIPTION
Upgrade addressable to ~> 2.9 to mitigate vulnerability GHSA-h27x-rffw-24p4.

Fixes: https://github.com/googleapis/google-api-ruby-client/issues/26054