### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: CI
+
+permissions:
+  contents: read
 on:
   pull_request:
     branches:
@@ -36,9 +39,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      with:
+        persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install tools
@@ -49,11 +54,13 @@ jobs:
       # See https://github.com/actions/runner-images/issues/10215
       # and https://github.com/rubygems/rubygems/issues/7983.
       shell: bash
+      # zizmor: ignore[template-injection]
       run: |
         if [ -d /opt/hostedtoolcache/Ruby ]; then
           chmod -R o-w /opt/hostedtoolcache/Ruby
         fi
     - name: Test ${{ matrix.task }} ${{ matrix.rubyopt }}
+      # zizmor: ignore[template-injection]
       run: |
         toys ci -v --only ${{ matrix.task }} --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }}
       env:

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -1,4 +1,7 @@
 name: Generate-Updates
+
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:
@@ -14,9 +17,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -1,4 +1,7 @@
 name: Freeze releases
+
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 
@@ -10,9 +13,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/release-unfreeze.yml
+++ b/.github/workflows/release-unfreeze.yml
@@ -1,4 +1,7 @@
 name: Unfreeze releases
+
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 
@@ -10,9 +13,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/weekly-generate-updates.yml
+++ b/.github/workflows/weekly-generate-updates.yml
@@ -1,4 +1,7 @@
 name: Weekly-Generate-Updates
+
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '02 9 * * 0'
@@ -11,9 +14,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: "4.0"
       - name: Install tools


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
