### PR TITLE
chore(actions): fix setup-ruby tag version in comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install tools

--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/release-unfreeze.yml
+++ b/.github/workflows/release-unfreeze.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
       - name: Install tools

--- a/.github/workflows/weekly-generate-updates.yml
+++ b/.github/workflows/weekly-generate-updates.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Ruby 4.0
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
       - name: Install tools


### PR DESCRIPTION
This addresses some incorrect version comments from the previous PR (Should be `v1.314.0` instead of `v1`). Here is the current output from zizmor:

```bash
$ zizmor --gh-token=$(gh auth token) --fix=all ./.github/workflows
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/generate-updates.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release-freeze.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release-unfreeze.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/weekly-generate-updates.yml
No findings to report. Good job! (1 ignored, 16 suppressed)
No fixes available to apply.
```