### PR TITLE
allow setting the faraday adapter to use

### DIFF
--- a/google-apis-core/lib/google/apis/core/base_service.rb
+++ b/google-apis-core/lib/google/apis/core/base_service.rb
@@ -557,6 +557,7 @@ module Google
           Faraday.new options do |faraday|
             faraday.response :logger, Google::Apis.logger if client_options.log_http_requests
             faraday.response :follow_redirects_google_apis_core, limit: 5
+            faraday.adapter client_options.adapter if client_options.adapter
           end
         end
 

--- a/google-apis-core/lib/google/apis/options.rb
+++ b/google-apis-core/lib/google/apis/options.rb
@@ -18,6 +18,7 @@ module Google
     ClientOptions = Struct.new(
       :application_name,
       :application_version,
+      :adapter,
       :proxy_url,
       :open_timeout_sec,
       :read_timeout_sec,
@@ -50,6 +51,8 @@ module Google
       #   @return [String] Name of the application, for identification in the User-Agent header
       # @!attribute [rw] application_version
       #   @return [String] Version of the application, for identification in the User-Agent header
+      # @!attribute [rw] adapter
+      #   @return [Symbol, Class] Faraday adapter to use
       # @!attribute [rw] proxy_url
       #   @return [String] URL of a proxy server
       # @!attribute [rw] log_http_requests


### PR DESCRIPTION
The application I work on uses httpclient and relies on its persistent connection feature and request hedging to keep p99 google storage uploads to a minimum. v1 changed to faraday, which is understandable, but the default faraday adapter uses net-http, which does not do persistent requests, and would severely limit our ability to seamlessly upgrade.

This patch introduces a new client option, `:adapter`, which allows setting a default adapter (faraday has several) which supports persistent connections via:

```ruby
Google::Apis::ClientOptions.default.adapter = :httpx # or
:net_http_persistent
```

Closes #27339 27339