### PR TITLE
fix(deps): add multi_json dependency to 8 legacy REST gems

### DIFF
--- a/generated/google-apis-analyticsdata_v1alpha/google-apis-analyticsdata_v1alpha.gemspec
+++ b/generated/google-apis-analyticsdata_v1alpha/google-apis-analyticsdata_v1alpha.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-appengine_v1beta4/google-apis-appengine_v1beta4.gemspec
+++ b/generated/google-apis-appengine_v1beta4/google-apis-appengine_v1beta4.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-appengine_v1beta5/google-apis-appengine_v1beta5.gemspec
+++ b/generated/google-apis-appengine_v1beta5/google-apis-appengine_v1beta5.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-cloudshell_v1alpha1/google-apis-cloudshell_v1alpha1.gemspec
+++ b/generated/google-apis-cloudshell_v1alpha1/google-apis-cloudshell_v1alpha1.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-genomics_v1/google-apis-genomics_v1.gemspec
+++ b/generated/google-apis-genomics_v1/google-apis-genomics_v1.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-genomics_v1alpha2/google-apis-genomics_v1alpha2.gemspec
+++ b/generated/google-apis-genomics_v1alpha2/google-apis-genomics_v1alpha2.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-youtube_analytics_v1/google-apis-youtube_analytics_v1.gemspec
+++ b/generated/google-apis-youtube_analytics_v1/google-apis-youtube_analytics_v1.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end

--- a/generated/google-apis-youtube_partner_v1/google-apis-youtube_partner_v1.gemspec
+++ b/generated/google-apis-youtube_partner_v1/google-apis-youtube_partner_v1.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
   gem.add_runtime_dependency "google-apis-core", "~> 0.1"
+  gem.add_runtime_dependency "multi_json", "~> 1.0"
 end


### PR DESCRIPTION
## Description
In 8 older, unregenerated REST client libraries (`cloudshell_v1alpha1`, `appengine_v1beta4`, `appengine_v1beta5`, `youtube_partner_v1`, `youtube_analytics_v1`, `genomics_v1`, `genomics_v1alpha2`, `analyticsdata_v1alpha`), the runtime constraint for `google-apis-core` is set to `~> 0.1` (`>= 0.1.0, < 1.0.0`).

This PR fixes a dormant CI load error in these 8 gems by explicitly adding `gem.add_runtime_dependency "multi_json", "~> 1.0"` to their `.gemspec` files while **preserving the original `google-apis-core ~> 0.1` constraint (no 1.x major version bump)**.

See [workflow run](https://github.com/googleapis/google-api-ruby-client/actions/runs/30664118729/job/91266962818#step:6:1784) for an example of the CI error.

---

### 💥 Reproducible Error Sample (Without This Fix)
When running tests (`bundle install && toys _nested spec` or `require "google/apis/cloudshell_v1alpha1"`) in any of these 8 legacy directories without `multi_json` in the bundle, RSpec/Bundler crashes with the following error:

```
  1) Google::Apis::CloudshellV1alpha1 should load
     Failure/Error:
       expect do
         require "google/apis/cloudshell_v1alpha1"
       end.not_to raise_error
     
       expected no Exception, got #<Gem::LoadError: multi_json is not part of the bundle. Add it to your Gemfile.> with backtrace:
         # /usr/local/google/home/torreypayne/.gem/ruby/3.2.0/gems/representable-3.2.0/lib/representable/json.rb:1:in `<top (required)>\'
         # /usr/local/google/home/torreypayne/.gem/ruby/3.2.0/gems/google-apis-core-0.18.0/lib/google/apis/core/json_representation.rb:15:in `<top (required)>\'
         # ./lib/google/apis/cloudshell_v1alpha1/service.rb:16:in `<top (required)>\'
         # ./lib/google/apis/cloudshell_v1alpha1.rb:15:in `<top (required)>\'
         # ./spec/generated_spec.rb:21:in `block (3 levels) in <top (required)>\'
         # ./spec/generated_spec.rb:20:in `block (2 levels) in <top (required)>\'
```

---

### 🔍 Why This Error Occurs
1. **Why `google-apis-core-0.18.0` is loaded:**
   The legacy library specifies `gem.add_runtime_dependency "google-apis-core", "~> 0.1"`, which restricts `google-apis-core` to the `0.x` major version series (resolving `0.18.0`).
2. **Why `representable-3.2.0` is loaded:**
   `google-apis-core (0.18.0)` requires `representable (~> 3.0)`, which resolves the latest 3.x version (`representable 3.2.0`).
3. **Why it crashes (`multi_json is not part of the bundle`):**
   `representable 3.2.0` calls `require "multi_json"`. However, because `google-apis-core 0.18.0` predates [PR #26612](https://github.com/googleapis/google-api-ruby-client/pull/26612) (which added an explicit runtime dependency on `multi_json` to `google-apis-core 1.2.1+`), neither `google-apis-core (0.18.0)` nor `representable (3.2.0)` declares a gem dependency on `multi_json`.
   When Bundler loads the gem (`require "bundler/setup"`), it blocks unlisted gems, raising `Gem::LoadError: multi_json is not part of the bundle`.

---

### 🛠️ Why This Fix Is Minimal & Safe
- **Zero Major Version Bump:** Instead of bumping `google-apis-core` to `1.x` (`>= 0.15.0, < 2.a`), we preserve `~> 0.1` so downstream consumers experience **no major version bump**.
- **Targeted Fix:** We simply add `gem.add_runtime_dependency "multi_json", "~> 1.0"` directly to the 8 legacy `.gemspec` files, ensuring `multi_json` is present in the bundle when `representable 3.2.0` loads.