### PR TITLE
chore: preserve and log full error backtraces in generate-updates

### DIFF
--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -167,9 +167,9 @@ def regen_single_gem api, version
       "--api=#{api}.#{version}",
       "--spot-check",
       "--names=#{context_directory}/api_names.yaml",
-      "--names-out=#{context_directory}/api_names_out.yaml"
+      "--names-out=#{context_directory}/api_names_out.yaml",
+      "--verbose"
     ]
-    cmd << "--verbose" if verbosity > 0
     result = exec cmd, in: [:string, "a\n"], out: [:capture, :inherit], err: [:capture, :inherit], e: false
     unless result.success?
       err_detail = result.captured_err.to_s.strip
@@ -188,9 +188,9 @@ def clean_old_gems
       "bundle", "exec",
       "bin/generate-api", "gen",
       "#{context_directory}/generated",
-      "--clean"
+      "--clean",
+      "--verbose"
     ]
-    cmd << "--verbose" if verbosity > 0
     result = exec cmd, out: [:capture, :inherit], err: [:capture, :inherit], e: false
     unless result.success?
       err_detail = result.captured_err.to_s.strip

--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -62,7 +62,14 @@ def run
   pr_clean_old_gems if clean
   unless @errors.empty?
     puts "Errors:", :red, :bold
-    @errors.each { |name| puts "Error generating #{name}", :red }
+    @errors.each do |err|
+      if err.is_a?(Hash)
+        puts "Error generating #{err[:name]} (exit code #{err[:exit_code]}):", :red, :bold
+        puts err[:error], :red if err[:error] && !err[:error].empty?
+      else
+        puts "Error generating #{err}", :red
+      end
+    end
     exit 1
   end
 end
@@ -162,8 +169,16 @@ def regen_single_gem api, version
       "--names=#{context_directory}/api_names.yaml",
       "--names-out=#{context_directory}/api_names_out.yaml"
     ]
-    result = exec cmd, in: [:string, "a\n"], e: false
-    yoshi_pr_generator.abort_capture! unless result.success?
+    cmd << "--verbose" if verbosity > 0
+    result = exec cmd, in: [:string, "a\n"], out: [:capture, :inherit], err: [:capture, :inherit], e: false
+    unless result.success?
+      err_detail = result.captured_err.to_s.strip
+      err_detail = result.captured_out.to_s.strip if err_detail.empty?
+      puts "Failed generating google-apis-#{api}_#{version} (exit code #{result.exit_code}):", :red, :bold
+      puts err_detail, :red unless err_detail.empty?
+      @errors << { name: "google-apis-#{api}_#{version}", exit_code: result.exit_code, error: err_detail }
+      yoshi_pr_generator.abort_capture!
+    end
   end
 end
 
@@ -175,8 +190,16 @@ def clean_old_gems
       "#{context_directory}/generated",
       "--clean"
     ]
-    result = exec cmd, e: false
-    yoshi_pr_generator.abort_capture! unless result.success?
+    cmd << "--verbose" if verbosity > 0
+    result = exec cmd, out: [:capture, :inherit], err: [:capture, :inherit], e: false
+    unless result.success?
+      err_detail = result.captured_err.to_s.strip
+      err_detail = result.captured_out.to_s.strip if err_detail.empty?
+      puts "Failed cleaning obsolete gems (exit code #{result.exit_code}):", :red, :bold
+      puts err_detail, :red unless err_detail.empty?
+      @errors << { name: "cleanup of obsolete gems", exit_code: result.exit_code, error: err_detail }
+      yoshi_pr_generator.abort_capture!
+    end
   end
 end
 

--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -175,6 +175,7 @@ def regen_single_gem api, version
       err_detail = result.captured_err.to_s.strip
       err_detail = result.captured_out.to_s.strip if err_detail.empty?
       puts "Failed generating google-apis-#{api}_#{version} (exit code #{result.exit_code}):", :red, :bold
+      puts "Discovery doc: https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/master/discoveries/#{api}.#{version}.json", :red
       puts err_detail, :red unless err_detail.empty?
       @errors << { name: "google-apis-#{api}_#{version}", exit_code: result.exit_code, error: err_detail }
       yoshi_pr_generator.abort_capture!


### PR DESCRIPTION
Part of stack to address b/542740217 (Apiary library generation errors preventing releases)

See bug for artifacts showing validation of the error output

## Summary
When `toys generate-updates` encounters an error generating a gem (e.g. `bin/generate-api` exits non-zero), the exit code and error backtraces were not captured or printed in the final summary output.

## Fix
1. Updated `regen_single_gem` and `clean_old_gems` in `.toys/generate-updates.rb` to capture `stdout` and `stderr` stream output via `out: [:capture, :inherit], err: [:capture, :inherit]`.
2. When generation fails, the error details and exit code are logged immediately and stored in `@errors`.
3. Updated the end-of-run summary in `generate-updates.rb` to print full error messages and backtraces for all failed gems.
4. Enabled `--verbose` output for `bin/generate-api` by default to preserve detailed error context.

### 📝 Exception Handling Logs

The following output demonstrates how these changes gracefully catch and report an anomalous Discovery configuration file (`discoveryengine.v1` crash) across both explicit and automated batch flows:

**1. Explicit CLI Execution (The `requested` flow)**
```bash
$ bundle exec toys generate-updates discoveryengine:v1
[2026-08-07 18:41:45  INFO]  exec: ["bundle", "install"]
Bundle complete! 27 Gemfile dependencies, 94 gems now installed.
(1/1) Error when generating google-apis-discoveryengine_v1
Errors:
Failed generating google-apis-discoveryengine_v1 (exit code 1):
Discovery doc: https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/master/discoveries/discoveryengine.v1.json
bundler: failed to load command: bin/generate-api (bin/generate-api)
/usr/local/google/home/torreypayne/google-api-ruby-client/google-apis-generator/lib/google/apis/generator/model.rb:46:in 'Google::Apis::DiscoveryV1::JsonSchema#qualified_name': undefined method 'qualified_name' for nil (NoMethodError)

          parent.qualified_name + '::' + generated_class_name
                ^^^^^^^^^^^^^^^
```

**2. Automated CI Execution (The `--all` flow)**
```bash
$ bundle exec toys generate-updates --all
Bundle complete! 27 Gemfile dependencies, 94 gems now installed.
(1/1) Error when generating google-apis-discoveryengine_v1
Errors:
Failed generating google-apis-discoveryengine_v1 (exit code 1):
Discovery doc: https://raw.githubusercontent.com/googleapis/discovery-artifact-manager/master/discoveries/discoveryengine.v1.json
bundler: failed to load command: bin/generate-api (bin/generate-api)
/usr/local/google/home/torreypayne/google-api-ruby-client/google-apis-generator/lib/google/apis/generator/model.rb:46:in 'Google::Apis::DiscoveryV1::JsonSchema#qualified_name': undefined method 'qualified_name' for nil (NoMethodError)

          parent.qualified_name + '::' + generated_class_name
                ^^^^^^^^^^^^^^^
```


