### PR TITLE
feat: respect api_list_config exclusions in generate-updates

### DIFF
--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "uri"
+require "psych"
 
 desc "Run standard Google client generation."
 
@@ -75,15 +76,30 @@ def run
 end
 
 def list_apis_versions
-  return requested.map { |request| request.split(":") } unless all
-  path = git_cache.find("https://github.com/googleapis/discovery-artifact-manager.git",
-                        path: "discoveries/index.json", update: true)
-  apis_versions = []
-  JSON.parse(File.read path)["items"].each do |item|
-    next unless item["preferred"] || gem_exists?(item)
-    apis_versions << [item["name"], item["version"]]
+  excluded = excluded_apis
+  if all
+    path = git_cache.find("https://github.com/googleapis/discovery-artifact-manager.git",
+                          path: "discoveries/index.json", update: true)
+    apis_versions = []
+    JSON.parse(File.read path)["items"].each do |item|
+      next if excluded.include?("#{item['name']}.#{item['version']}") || excluded.include?("#{item['name']}:#{item['version']}")
+      next unless item["preferred"] || gem_exists?(item)
+      apis_versions << [item["name"], item["version"]]
+    end
+    apis_versions.shuffle
+  else
+    requested.map { |request| request.split(":") }.reject do |(name, version)|
+      excluded.include?("#{name}.#{version}") || excluded.include?("#{name}:#{version}")
+    end
   end
-  apis_versions.shuffle
+end
+
+def excluded_apis
+  config_path = "#{context_directory}/api_list_config.yaml"
+  return [] unless File.file?(config_path)
+  Psych.load_file(config_path)["exclude"] || []
+rescue StandardError
+  []
 end
 
 def gem_exists? item

--- a/api_list_config.yaml
+++ b/api_list_config.yaml
@@ -5,5 +5,8 @@ include:
   - name: youtubePartner
     version: v1
     discovery_rest_url: https://content.googleapis.com/discovery/v1/apis/youtubePartner/v1/rest
-exclude: []
+exclude:
+  - discoveryengine.v1
+  - discoveryengine.v1alpha
+  - discoveryengine.v1beta
 pause: []


### PR DESCRIPTION
Part 2 of stack to address b/542740217 (Apiary library generation errors preventing releases)

Source-Link: https://b.corp.google.com/issues/542740217

## Summary
Excludes `discoveryengine.v1`, `discoveryengine.v1alpha`, and `discoveryengine.v1beta` from client generation until the upstream Discovery doc issue is resolved.

## Changes
1. Added `discoveryengine.v1`, `discoveryengine.v1alpha`, `discoveryengine.v1beta` to `exclude:` list in `api_list_config.yaml`.
2. Updated `.toys/generate-updates.rb` to require `psych` and reject excluded APIs in `list_apis_versions` for both `--all` and explicit `requested` runs.