### PR TITLE
feat: respect api_list_config exclusions in generate-updates

### DIFF
--- a/.toys/generate-updates.rb
+++ b/.toys/generate-updates.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "uri"
+require "psych"
 
 desc "Run standard Google client generation."
 
@@ -75,15 +76,32 @@ def run
 end
 
 def list_apis_versions
-  return requested.map { |request| request.split(":") } unless all
-  path = git_cache.find("https://github.com/googleapis/discovery-artifact-manager.git",
-                        path: "discoveries/index.json", update: true)
-  apis_versions = []
-  JSON.parse(File.read path)["items"].each do |item|
-    next unless item["preferred"] || gem_exists?(item)
-    apis_versions << [item["name"], item["version"]]
+  excluded = excluded_apis
+  
+  result = if all
+    path = git_cache.find("https://github.com/googleapis/discovery-artifact-manager.git",
+                          path: "discoveries/index.json", update: true)
+    apis_versions = []
+    JSON.parse(File.read(path))["items"].each do |item|
+      next unless item["preferred"] || gem_exists?(item)
+      apis_versions << [item["name"], item["version"]]
+    end
+    apis_versions.shuffle
+  else
+    requested.map { |request| request.split(":") }
   end
-  apis_versions.shuffle
+  
+  result.reject do |(name, version)|
+    excluded.include?("#{name}.#{version}") || excluded.include?("#{name}:#{version}")
+  end
+end
+
+def excluded_apis
+  config_path = "#{context_directory}/api_list_config.yaml"
+  return [] unless File.file?(config_path)
+  Psych.load_file(config_path)["exclude"] || []
+rescue StandardError
+  []
 end
 
 def gem_exists? item

--- a/api_list_config.yaml
+++ b/api_list_config.yaml
@@ -5,5 +5,8 @@ include:
   - name: youtubePartner
     version: v1
     discovery_rest_url: https://content.googleapis.com/discovery/v1/apis/youtubePartner/v1/rest
-exclude: []
+exclude:
+  - discoveryengine.v1
+  - discoveryengine.v1alpha
+  - discoveryengine.v1beta
 pause: []


### PR DESCRIPTION
Part of stack to address b/542740217

Respects the exclude configuration from `api_list_config.yaml`. Filters out the discovery doc at generate time.

Relates to #27557 which was accidentally closed.